### PR TITLE
use IConnectionMultiplexer instead of ConnectionMultiplexer

### DIFF
--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -4,11 +4,11 @@ using StackExchange.Redis;
 
 namespace Foundatio.Caching {
     public class RedisCacheClientOptions : SharedOptions {
-        public ConnectionMultiplexer ConnectionMultiplexer { get; set; }
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
     }
 
     public class RedisCacheClientOptionsBuilder : SharedOptionsBuilder<RedisCacheClientOptions, RedisCacheClientOptionsBuilder> {
-        public RedisCacheClientOptionsBuilder ConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer) {
+        public RedisCacheClientOptionsBuilder ConnectionMultiplexer(IConnectionMultiplexer connectionMultiplexer) {
             Target.ConnectionMultiplexer = connectionMultiplexer;
             return this;
         }

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -70,7 +70,7 @@ namespace Foundatio.Redis {
     }
 
     public static class RedisExtensions {
-        public static bool IsCluster(this ConnectionMultiplexer muxer) {
+        public static bool IsCluster(this IConnectionMultiplexer muxer) {
             var configuration = ConfigurationOptions.Parse(muxer.Configuration);
             if (configuration.Proxy == Proxy.Twemproxy)
                 return true;

--- a/src/Foundatio.Redis/Metrics/RedisMetricsClientOptions.cs
+++ b/src/Foundatio.Redis/Metrics/RedisMetricsClientOptions.cs
@@ -3,11 +3,11 @@ using StackExchange.Redis;
 
 namespace Foundatio.Metrics {
     public class RedisMetricsClientOptions : SharedMetricsClientOptions {
-        public ConnectionMultiplexer ConnectionMultiplexer { get; set; }
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
     }
 
     public class RedisMetricsClientOptionsBuilder : SharedMetricsClientOptionsBuilder<RedisMetricsClientOptions, RedisMetricsClientOptionsBuilder> {
-        public RedisMetricsClientOptionsBuilder ConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer) {
+        public RedisMetricsClientOptionsBuilder ConnectionMultiplexer(IConnectionMultiplexer connectionMultiplexer) {
             Target.ConnectionMultiplexer = connectionMultiplexer;
             return this;
         }

--- a/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
@@ -4,7 +4,7 @@ using StackExchange.Redis;
 namespace Foundatio.Queues {
     // TODO: Make queue settings immutable and stored in redis so that multiple clients can't have different settings.
     public class RedisQueueOptions<T> : SharedQueueOptions<T> where T : class {
-        public ConnectionMultiplexer ConnectionMultiplexer { get; set; }
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
         public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMinutes(1);
         public int[] RetryMultipliers { get; set; } = { 1, 3, 5, 10 };
         public TimeSpan DeadLetterTimeToLive { get; set; } = TimeSpan.FromDays(1);
@@ -13,7 +13,7 @@ namespace Foundatio.Queues {
     }
 
     public class RedisQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T, RedisQueueOptions<T>, RedisQueueOptionsBuilder<T>> where T: class {
-        public RedisQueueOptionsBuilder<T> ConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer) {
+        public RedisQueueOptionsBuilder<T> ConnectionMultiplexer(IConnectionMultiplexer connectionMultiplexer) {
             Target.ConnectionMultiplexer = connectionMultiplexer;
             return this;
         }

--- a/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
@@ -3,12 +3,12 @@ using StackExchange.Redis;
 
 namespace Foundatio.Storage {
     public class RedisFileStorageOptions : SharedOptions {
-        public ConnectionMultiplexer ConnectionMultiplexer { get; set; }
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
         public string ContainerName { get; set; } = "storage";
     }
 
     public class RedisFileStorageOptionsBuilder : SharedOptionsBuilder<RedisFileStorageOptions, RedisFileStorageOptionsBuilder> {
-        public RedisFileStorageOptionsBuilder ConnectionMultiplexer(ConnectionMultiplexer connectionMultiplexer) {
+        public RedisFileStorageOptionsBuilder ConnectionMultiplexer(IConnectionMultiplexer connectionMultiplexer) {
             Target.ConnectionMultiplexer = connectionMultiplexer;
             return this;
         }


### PR DESCRIPTION
Thanks for building this library. It's been tremendously useful for my project and has saved us so much time.

I'm trying to trace Redis calls with OpenTracing by using my own IConnectionMultiplexer implementation that returns my own IDatabase implementation. However I can't use it with Foundatio.Redis because the configuration requires a ConnectionMultiplexer instead of an IConnectionMultiplexer.

Changing Foundatio.Redis to take the interface instead appears to be as simple as changing it in these options classes and an extension method. It compiles and all tests pass for me.