### PR TITLE
added redisChannelName for RedisHybridCacheClient so that users can s…

### DIFF
--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Foundatio.Serializer;
 using StackExchange.Redis;
 

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -6,19 +6,19 @@ using StackExchange.Redis;
 
 namespace Foundatio.Caching {
     public class RedisHybridCacheClient : HybridCacheClient {
-        public RedisHybridCacheClient(RedisCacheClientOptions options, InMemoryCacheClientOptions localOptions = null)
+        public RedisHybridCacheClient(RedisCacheClientOptions options, InMemoryCacheClientOptions localOptions = null, string redisChannelName = "cache-messages")
             : base(new RedisCacheClient(o => o
                 .ConnectionMultiplexer(options.ConnectionMultiplexer)
                 .Serializer(options.Serializer)
                 .LoggerFactory(options.LoggerFactory)),
             new RedisMessageBus(o => o
                 .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
-                .Topic("cache-messages")
+                .Topic(redisChannelName)
                 .Serializer(options.Serializer)
                 .LoggerFactory(options.LoggerFactory)), localOptions, options.LoggerFactory) { }
 
-        public RedisHybridCacheClient(Builder<RedisCacheClientOptionsBuilder, RedisCacheClientOptions> config, Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions> localConfig = null)
-            : this(config(new RedisCacheClientOptionsBuilder()).Build(), localConfig(new InMemoryCacheClientOptionsBuilder()).Build()) { }
+        public RedisHybridCacheClient(Builder<RedisCacheClientOptionsBuilder, RedisCacheClientOptions> config, Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions> localConfig = null, string redisChannelName = "cache-messages")
+            : this(config(new RedisCacheClientOptionsBuilder()).Build(), localConfig(new InMemoryCacheClientOptionsBuilder()).Build(), redisChannelName) { }
 
         public override void Dispose() {
             base.Dispose();

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -5,20 +5,21 @@ using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Foundatio.Caching {
+
     public class RedisHybridCacheClient : HybridCacheClient {
-        public RedisHybridCacheClient(RedisCacheClientOptions options, InMemoryCacheClientOptions localOptions = null, string redisChannelName = "cache-messages")
+        public RedisHybridCacheClient(RedisHybridCacheClientOptions options, InMemoryCacheClientOptions localOptions = null)
             : base(new RedisCacheClient(o => o
                 .ConnectionMultiplexer(options.ConnectionMultiplexer)
                 .Serializer(options.Serializer)
                 .LoggerFactory(options.LoggerFactory)),
             new RedisMessageBus(o => o
                 .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
-                .Topic(redisChannelName)
+                .Topic(options.RedisChannelName)
                 .Serializer(options.Serializer)
                 .LoggerFactory(options.LoggerFactory)), localOptions, options.LoggerFactory) { }
 
-        public RedisHybridCacheClient(Builder<RedisCacheClientOptionsBuilder, RedisCacheClientOptions> config, Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions> localConfig = null, string redisChannelName = "cache-messages")
-            : this(config(new RedisCacheClientOptionsBuilder()).Build(), localConfig(new InMemoryCacheClientOptionsBuilder()).Build(), redisChannelName) { }
+        public RedisHybridCacheClient(Builder<RedisHybridCacheClientOptionsBuilder, RedisHybridCacheClientOptions> config, Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions> localConfig = null)
+            : this(config(new RedisHybridCacheClientOptionsBuilder()).Build(), localConfig(new InMemoryCacheClientOptionsBuilder()).Build()) { }
 
         public override void Dispose() {
             base.Dispose();

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClientOptions.cs
@@ -1,0 +1,21 @@
+﻿using StackExchange.Redis;
+
+namespace Foundatio.Caching {
+    public class RedisHybridCacheClientOptions : RedisCacheClientOptions {
+        public string RedisChannelName { get; set; } = "cache-messages";
+    }
+
+    public class RedisHybridCacheClientOptionsBuilder :
+        SharedOptionsBuilder<RedisHybridCacheClientOptions, RedisHybridCacheClientOptionsBuilder> {
+
+        public RedisHybridCacheClientOptionsBuilder ConnectionMultiplexer(IConnectionMultiplexer connectionMultiplexer) {
+            Target.ConnectionMultiplexer = connectionMultiplexer;
+            return this;
+        }
+
+        public RedisHybridCacheClientOptionsBuilder RedisChannelName(string redisChannelName) {
+            Target.RedisChannelName = redisChannelName;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This is pull request following #15.

In my opinion, redis channel/topic name is not related to `RedisCacheClientOptions` so I added a third argument for both constructors. 

The downside is that the constructor uses builder does not look fluent any more... Do you prefer wrapping it into a builder argument?