### PR TITLE
Fixes #73 ReplaceIfEqualAsync sets a wrong expiration value causing RenewAsync to release locks

### DIFF
--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -353,7 +353,7 @@ namespace Foundatio.Queues {
                         workListName = _workListName,
                         queueName = _options.Name,
                         now,
-                        timeout = timeout.Ticks
+                        timeout = timeout.TotalSeconds
                     }).AnyContext();
                     return result.ToString();
                 }, 3, TimeSpan.FromMilliseconds(100), linkedCancellationToken, _logger).AnyContext();                

--- a/src/Foundatio.Redis/Scripts/ReplaceIfEqual.lua
+++ b/src/Foundatio.Redis/Scripts/ReplaceIfEqual.lua
@@ -1,7 +1,7 @@
 ﻿local currentVal = redis.call('get', @key)
 if (currentVal == false or currentVal == @expected) then
   if (@expires ~= nil and @expires ~= '') then
-    return redis.call('set', @key, @value, 'PX', @expires) and 1 or 0
+    return redis.call('set', @key, @value, 'EX', @expires) and 1 or 0
   else
     return redis.call('set', @key, @value) and 1 or 0
   end


### PR DESCRIPTION
Looks like dequeue id had the same problem. I also noticed that our ReplaceIfEqualAsync base unit tests doesn't check expiration but I didn't have time to rework that.

Docs: https://redis.io/commands/set