### PR TITLE
redis cluster support

### DIFF
--- a/src/Foundatio.Redis/Scripts/DequeueId.lua
+++ b/src/Foundatio.Redis/Scripts/DequeueId.lua
@@ -1,7 +1,7 @@
 ﻿local item = redis.call('RPOPLPUSH', @queueListName, @workListName);
 if item then
-    local dequeuedTimeKey = 'q:' .. @queueName .. ':' .. item .. ':dequeued';
-    local renewedTimeKey = 'q:' .. @queueName .. ':' .. item .. ':renewed';
+    local dequeuedTimeKey = @listPrefix .. ':' .. item .. ':dequeued';
+    local renewedTimeKey = @listPrefix .. ':' .. item .. ':renewed';
     redis.call('SET', dequeuedTimeKey, @now, 'PX', @timeout);
     redis.call('SET', renewedTimeKey, @now, 'PX', @timeout);
     return item;


### PR DESCRIPTION
This version will actually work against redis cluster (and non redis cluster).

Validated against a keydb based cluster CI environment and a redis-server standalone.

Key changes include:
 - consistent key prefixing with `{}`
 - Use of RedisKey in lua script generation to ensure the correct server receives the EVAL