### PR TITLE
Replace removeByPrefix Lua script with Scan

### DIFF
--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -75,6 +75,31 @@ namespace Foundatio.Redis.Tests.Caching {
             return base.CanRemoveByPrefixAsync();
         }
 
+        [Theory]
+        [InlineData(50)]
+        [InlineData(500)]
+        [InlineData(5000)]
+        [InlineData(50000)]
+        public virtual async Task CanRemoveByPrefixMultipleEntriesAsync(int count) {
+            var cache = GetCacheClient();
+            if (cache == null)
+                return;
+
+            using (cache) {
+                await cache.RemoveAllAsync();
+                const string prefix = "blah:";
+                await cache.SetAsync("test", 1);
+
+                await cache.SetAllAsync(Enumerable.Range(0, count).ToDictionary(i => prefix + "test" + i));
+
+                Assert.Equal(1, (await cache.GetAsync<int>(prefix + "test" + 1)).Value);
+                Assert.Equal(1, (await cache.GetAsync<int>("test")).Value);
+
+                Assert.Equal(0, await cache.RemoveByPrefixAsync(prefix + ":doesntexist"));
+                Assert.Equal(count, await cache.RemoveByPrefixAsync(prefix));
+            }
+        }
+
         [Fact]
         public override Task CanSetExpirationAsync() {
             return base.CanSetExpirationAsync();


### PR DESCRIPTION
Resolves the issue https://github.com/FoundatioFx/Foundatio.Redis/issues/78

#### Description of the change
Replace the Lua script that removes keys based on a prefix with multiple calls.
Bulk calls made to remove the detected keys by chunks of 2500.

_Note: 2500 was chosen empirically after several rounds of testing. The value can be adjusted._

SCAN is being used over KEYS to avoid blocking operations.

#### Motivation
According to the official documentation:
https://redis.io/commands/eval/

> Important: to ensure the correct execution of scripts, both in standalone and clustered deployments, all names of keys that a script accesses must be explicitly provided as input key arguments. The script should only access keys whose names are given as input arguments. Scripts should never access keys with programmatically-generated names or based on the contents of data structures stored in the database.

After some testing, the issue happens when trying to remove between 7500 and 8000 entries by prefix.