### PR TITLE
Support different read mode in RedisHybridCacheClient

### DIFF
--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -32,7 +32,7 @@ namespace Foundatio.Caching
             return this;
         }
 
-        public RedisCacheClientOptionsBuilder ReadMode (CommandFlags commandFlags)
+        public RedisCacheClientOptionsBuilder ReadMode(CommandFlags commandFlags)
         {
             Target.ReadMode = commandFlags;
             return this;

--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -32,7 +32,7 @@ namespace Foundatio.Caching
             return this;
         }
 
-        public RedisCacheClientOptionsBuilder ReadMode(CommandFlags commandFlags)
+        public RedisCacheClientOptionsBuilder ReadMode (CommandFlags commandFlags)
         {
             Target.ReadMode = commandFlags;
             return this;

--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -31,5 +31,11 @@ namespace Foundatio.Caching
             Target.ShouldThrowOnSerializationError = shouldThrow;
             return this;
         }
+
+        public RedisCacheClientOptionsBuilder ReadMode(CommandFlags commandFlags)
+        {
+            Target.ReadMode = commandFlags;
+            return this;
+        }
     }
 }

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -10,7 +10,8 @@ namespace Foundatio.Caching
                 .ConnectionMultiplexer(options.ConnectionMultiplexer)
                 .Serializer(options.Serializer)
                 .LoggerFactory(options.LoggerFactory)
-                .ShouldThrowOnSerializationError(options.ShouldThrowOnSerializationError)),
+                .ShouldThrowOnSerializationError(options.ShouldThrowOnSerializationError)
+                .ReadMode(options.ReadMode)),
             new RedisMessageBus(o => o
                 .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
                 .Topic(options.RedisChannelName)


### PR DESCRIPTION
At the moment, Even if we setup the Read mode in **RedisHybridCacheClientOptions** while creating the **RedisHybridCacheClient** instance, it doesn't work when we access the Redis.

The reason for that is because when we call the base object like this, we didn't pass the options.ReadMode in.
https://github.com/FoundatioFx/Foundatio.Redis/blob/ceb704b100ef519ea9adbc391b45fe56a5384691/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs#L9

So the base readmode is always **CommandFlags.None**.
https://github.com/FoundatioFx/Foundatio.Redis/blob/ceb704b100ef519ea9adbc391b45fe56a5384691/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs#L17

Here is the example before/after the code update when we set the read mode as **PreferReplica**, the GetTypeCmds indicates the total number of read-only type commands. This is derived from the Redis commandstats statistic by summing all of the read-only type commands (get, hget, scard, lrange, and so on.):

The 001 nodes of both shards are the masters:
<img width="470" alt="image" src="https://github.com/FoundatioFx/Foundatio.Redis/assets/43327562/3cdccf7d-5848-4e20-a942-3c43adcab10f">

Before the code update, we can see all the read call still goes to the master node.
<img width="473" alt="image" src="https://github.com/FoundatioFx/Foundatio.Redis/assets/43327562/6aa1b7b4-dfee-40c0-96b4-5e33fea3b9d4">

After the code update, the application starts fetching data from read replica.
<img width="731" alt="image" src="https://github.com/FoundatioFx/Foundatio.Redis/assets/43327562/61765b25-118b-4133-8311-adf919880387">


