### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,23 +28,19 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        ArgumentNullException.ThrowIfNull(queueEntry.Value);
-
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value!.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<PingRequest> context)
     {
-        ArgumentNullException.ThrowIfNull(context.QueueEntry.Value);
-
         Interlocked.Increment(ref _runCount);
 
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
+        if (RandomData.GetBool(context.QueueEntry.Value!.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,11 +28,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        if (queueEntry.Value is null)
-        {
-            _logger.LogWarning("Queue entry value is null, skipping lock acquisition");
-            return Task.FromResult<ILock?>(null);
-        }
+        ArgumentNullException.ThrowIfNull(queueEntry.Value);
 
         return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
             TimeSpan.FromMinutes(30),
@@ -41,11 +37,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<PingRequest> context)
     {
-        if (context.QueueEntry.Value is null)
-        {
-            _logger.LogWarning("Queue entry value is null");
-            return JobResult.Success;
-        }
+        ArgumentNullException.ThrowIfNull(context.QueueEntry.Value);
 
         Interlocked.Increment(ref _runCount);
 
@@ -59,9 +51,9 @@ public class PingQueueJob : QueueJobBase<PingRequest>
     }
 }
 
-public class PingRequest
+public record PingRequest
 {
-    public string Data { get; set; } = null!;
-    public string Id { get; set; } = null!;
-    public int PercentChanceOfException { get; set; } = 0;
+    public required string Data { get; set; }
+    public required string Id { get; set; }
+    public int PercentChanceOfException { get; set; }
 }

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,19 +28,31 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value?.Id),
+        if (queueEntry.Value is null)
+        {
+            _logger.LogWarning("Queue entry has null value, skipping lock acquisition");
+            return Task.FromResult<ILock?>(null);
+        }
+
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<PingRequest> context)
     {
+        if (context.QueueEntry.Value is null)
+        {
+            _logger.LogWarning("Queue entry has null value, skipping processing");
+            return JobResult.Success;
+        }
+
         Interlocked.Increment(ref _runCount);
 
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value!.PercentChanceOfException))
+        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,19 +28,31 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value?.Id),
+        if (queueEntry.Value is null)
+        {
+            _logger.LogWarning("Queue entry value is null, skipping lock acquisition");
+            return Task.FromResult<ILock?>(null);
+        }
+
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<PingRequest> context)
     {
+        if (context.QueueEntry.Value is null)
+        {
+            _logger.LogWarning("Queue entry value is null");
+            return JobResult.Success;
+        }
+
         Interlocked.Increment(ref _runCount);
 
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value?.PercentChanceOfException ?? 0))
+        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Exceptionless;
@@ -26,9 +26,9 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     public int RunCount => _runCount;
 
-    protected override Task<ILock> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
+    protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value?.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
@@ -40,7 +40,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
+        if (RandomData.GetBool(context.QueueEntry.Value?.PercentChanceOfException ?? 0))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;
@@ -49,7 +49,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
 public class PingRequest
 {
-    public string Data { get; set; }
-    public string Id { get; set; }
+    public string Data { get; set; } = null!;
+    public string Id { get; set; } = null!;
     public int PercentChanceOfException { get; set; } = 0;
 }

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,7 +28,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value!.Id),
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value?.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
@@ -40,7 +40,10 @@ public class PingQueueJob : QueueJobBase<PingRequest>
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value!.PercentChanceOfException))
+        if (context.QueueEntry.Value is null)
+            return JobResult.FailedWithMessage("Queue entry value is null");
+
+        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -40,10 +40,7 @@ public class PingQueueJob : QueueJobBase<PingRequest>
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (context.QueueEntry.Value is null)
-            return JobResult.FailedWithMessage("Queue entry value is null");
-
-        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
+        if (RandomData.GetBool(context.QueueEntry.Value!.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/PingQueueJob.cs
+++ b/samples/Foundatio.SampleJob/PingQueueJob.cs
@@ -28,31 +28,19 @@ public class PingQueueJob : QueueJobBase<PingRequest>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<PingRequest> queueEntry, CancellationToken cancellationToken = new CancellationToken())
     {
-        if (queueEntry.Value is null)
-        {
-            _logger.LogWarning("Queue entry has null value, skipping lock acquisition");
-            return Task.FromResult<ILock?>(null);
-        }
-
-        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value.Id),
+        return _locker.AcquireAsync(String.Concat("pull:", queueEntry.Value!.Id),
             TimeSpan.FromMinutes(30),
             TimeSpan.FromSeconds(1));
     }
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<PingRequest> context)
     {
-        if (context.QueueEntry.Value is null)
-        {
-            _logger.LogWarning("Queue entry has null value, skipping processing");
-            return JobResult.Success;
-        }
-
         Interlocked.Increment(ref _runCount);
 
         _logger.LogInformation("Got {RunCount} ping. Sending pong!", RunCount.ToOrdinal());
         await Task.Delay(TimeSpan.FromMilliseconds(1)).AnyContext();
 
-        if (RandomData.GetBool(context.QueueEntry.Value.PercentChanceOfException))
+        if (RandomData.GetBool(context.QueueEntry.Value!.PercentChanceOfException))
             throw new ApplicationException("Boom!");
 
         return JobResult.Success;

--- a/samples/Foundatio.SampleJob/Program.cs
+++ b/samples/Foundatio.SampleJob/Program.cs
@@ -27,7 +27,7 @@ public class Program
     }
 }
 
-public class EchoMessage
+public record EchoMessage
 {
-    public string Message { get; set; } = null!;
+    public required string Message { get; set; }
 }

--- a/samples/Foundatio.SampleJob/Program.cs
+++ b/samples/Foundatio.SampleJob/Program.cs
@@ -7,7 +7,7 @@ namespace Foundatio.SampleJob;
 
 public class Program
 {
-    private static ILogger _logger;
+    private static ILogger _logger = null!;
 
     public static int Main()
     {
@@ -29,5 +29,5 @@ public class Program
 
 public class EchoMessage
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }

--- a/samples/Foundatio.SampleJob/SampleServiceProvider.cs
+++ b/samples/Foundatio.SampleJob/SampleServiceProvider.cs
@@ -23,9 +23,9 @@ public class SampleServiceProvider
 
         var muxer = ConnectionMultiplexer.Connect("localhost", o => o.LoggerFactory = loggerFactory);
         container.AddSingleton(muxer);
-        container.AddSingleton<IQueue<PingRequest>>(s => new RedisQueue<PingRequest>(o => o.ConnectionMultiplexer(muxer).RetryDelay(TimeSpan.FromSeconds(1)).WorkItemTimeout(TimeSpan.FromSeconds(5)).LoggerFactory(loggerFactory)));
-        container.AddSingleton<ICacheClient>(s => new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(loggerFactory)));
-        container.AddSingleton<IMessageBus>(s => new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).LoggerFactory(loggerFactory).MapMessageTypeToClassName<EchoMessage>()));
+        container.AddSingleton<IQueue<PingRequest>>(s => new RedisQueue<PingRequest>(o => o.ConnectionMultiplexer(muxer).RetryDelay(TimeSpan.FromSeconds(1)).WorkItemTimeout(TimeSpan.FromSeconds(5)).LoggerFactory(loggerFactory!)));
+        container.AddSingleton<ICacheClient>(s => new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(loggerFactory!)));
+        container.AddSingleton<IMessageBus>(s => new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).LoggerFactory(loggerFactory!).MapMessageTypeToClassName<EchoMessage>()));
         container.AddSingleton<ILockProvider>(s => new CacheLockProvider(s.GetRequiredService<ICacheClient>(), s.GetRequiredService<IMessageBus>(), null, loggerFactory));
         container.AddTransient<PingQueueJob>();
 

--- a/samples/Foundatio.SampleJob/SampleServiceProvider.cs
+++ b/samples/Foundatio.SampleJob/SampleServiceProvider.cs
@@ -11,7 +11,7 @@ namespace Foundatio.SampleJob;
 
 public class SampleServiceProvider
 {
-    public static IServiceProvider Create(ILoggerFactory loggerFactory)
+    public static IServiceProvider Create(ILoggerFactory? loggerFactory)
     {
         var container = new ServiceCollection();
 
@@ -23,9 +23,9 @@ public class SampleServiceProvider
 
         var muxer = ConnectionMultiplexer.Connect("localhost", o => o.LoggerFactory = loggerFactory);
         container.AddSingleton(muxer);
-        container.AddSingleton<IQueue<PingRequest>>(s => new RedisQueue<PingRequest>(o => o.ConnectionMultiplexer(muxer).RetryDelay(TimeSpan.FromSeconds(1)).WorkItemTimeout(TimeSpan.FromSeconds(5)).LoggerFactory(loggerFactory!)));
-        container.AddSingleton<ICacheClient>(s => new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(loggerFactory!)));
-        container.AddSingleton<IMessageBus>(s => new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).LoggerFactory(loggerFactory!).MapMessageTypeToClassName<EchoMessage>()));
+        container.AddSingleton<IQueue<PingRequest>>(s => new RedisQueue<PingRequest>(o => o.ConnectionMultiplexer(muxer).RetryDelay(TimeSpan.FromSeconds(1)).WorkItemTimeout(TimeSpan.FromSeconds(5)).LoggerFactory(loggerFactory)));
+        container.AddSingleton<ICacheClient>(s => new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(loggerFactory)));
+        container.AddSingleton<IMessageBus>(s => new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).LoggerFactory(loggerFactory).MapMessageTypeToClassName<EchoMessage>()));
         container.AddSingleton<ILockProvider>(s => new CacheLockProvider(s.GetRequiredService<ICacheClient>(), s.GetRequiredService<IMessageBus>(), null, loggerFactory));
         container.AddTransient<PingQueueJob>();
 

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.48" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.42" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.32" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.36" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.41" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.42" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.43" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.41" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.48" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.35" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta3.36" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Foundatio.SampleJobClient/Program.cs
+++ b/samples/Foundatio.SampleJobClient/Program.cs
@@ -15,7 +15,7 @@ public class Program
     private static IQueue<PingRequest> _queue = null!;
     private static IMessageBus _messageBus = null!;
     private static TestLogger _loggerFactory = null!;
-    private static ILogger? _logger;
+    private static ILogger _logger = null!;
     private static bool _isRunning = true;
     private static CancellationTokenSource _continuousEnqueueTokenSource = new();
 
@@ -39,7 +39,7 @@ public class Program
         for (int i = 0; i < count; i++)
             _queue.EnqueueAsync(new PingRequest { Data = "b", PercentChanceOfException = 0 }).GetAwaiter().GetResult();
 
-        _logger?.LogInformation("Enqueued {Count} ping requests", count);
+        _logger.LogInformation("Enqueued {Count} ping requests", count);
     }
 
     private static void EnqueueContinuousPings(int count, CancellationToken token)
@@ -49,7 +49,7 @@ public class Program
             for (int i = 0; i < count; i++)
                 _queue.EnqueueAsync(new PingRequest { Data = "b", PercentChanceOfException = 0 }).GetAwaiter().GetResult();
 
-            _logger?.LogInformation("Enqueued {Count} ping requests", count);
+            _logger.LogInformation("Enqueued {Count} ping requests", count);
         } while (!token.IsCancellationRequested);
     }
 
@@ -68,7 +68,7 @@ public class Program
             if (_continuousEnqueueTokenSource.IsCancellationRequested)
                 _continuousEnqueueTokenSource = new CancellationTokenSource();
 
-            _logger?.LogWarning("Starting continuous ping...");
+            _logger.LogWarning("Starting continuous ping...");
             Task.Run(() => EnqueueContinuousPings(25, _continuousEnqueueTokenSource.Token), _continuousEnqueueTokenSource.Token);
         }
         else if (key == ConsoleKey.M)
@@ -81,7 +81,7 @@ public class Program
         }
         else if (key == ConsoleKey.S)
         {
-            _logger?.LogWarning("Cancelling continuous ping.");
+            _logger.LogWarning("Cancelling continuous ping.");
             _continuousEnqueueTokenSource.Cancel();
         }
     }

--- a/samples/Foundatio.SampleJobClient/Program.cs
+++ b/samples/Foundatio.SampleJobClient/Program.cs
@@ -210,14 +210,14 @@ public class Program
     }
 }
 
-public class EchoMessage
+public record EchoMessage
 {
-    public string Message { get; set; } = null!;
+    public required string Message { get; set; }
 }
 
-public class PingRequest
+public record PingRequest
 {
-    public string Data { get; set; } = null!;
+    public required string Data { get; set; }
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
-    public int PercentChanceOfException { get; set; } = 0;
+    public int PercentChanceOfException { get; set; }
 }

--- a/samples/Foundatio.SampleJobClient/Program.cs
+++ b/samples/Foundatio.SampleJobClient/Program.cs
@@ -12,10 +12,10 @@ namespace Foundatio.SampleJobClient;
 
 public class Program
 {
-    private static IQueue<PingRequest> _queue;
-    private static IMessageBus _messageBus;
-    private static TestLogger _loggerFactory;
-    private static ILogger _logger;
+    private static IQueue<PingRequest> _queue = null!;
+    private static IMessageBus _messageBus = null!;
+    private static TestLogger _loggerFactory = null!;
+    private static ILogger _logger = null!;
     private static bool _isRunning = true;
     private static CancellationTokenSource _continuousEnqueueTokenSource = new();
 
@@ -212,12 +212,12 @@ public class Program
 
 public class EchoMessage
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 }
 
 public class PingRequest
 {
-    public string Data { get; set; }
+    public string Data { get; set; } = null!;
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
     public int PercentChanceOfException { get; set; } = 0;
 }

--- a/samples/Foundatio.SampleJobClient/Program.cs
+++ b/samples/Foundatio.SampleJobClient/Program.cs
@@ -15,7 +15,7 @@ public class Program
     private static IQueue<PingRequest> _queue = null!;
     private static IMessageBus _messageBus = null!;
     private static TestLogger _loggerFactory = null!;
-    private static ILogger _logger = null!;
+    private static ILogger? _logger;
     private static bool _isRunning = true;
     private static CancellationTokenSource _continuousEnqueueTokenSource = new();
 
@@ -39,7 +39,7 @@ public class Program
         for (int i = 0; i < count; i++)
             _queue.EnqueueAsync(new PingRequest { Data = "b", PercentChanceOfException = 0 }).GetAwaiter().GetResult();
 
-        _logger.LogInformation("Enqueued {Count} ping requests", count);
+        _logger?.LogInformation("Enqueued {Count} ping requests", count);
     }
 
     private static void EnqueueContinuousPings(int count, CancellationToken token)
@@ -49,7 +49,7 @@ public class Program
             for (int i = 0; i < count; i++)
                 _queue.EnqueueAsync(new PingRequest { Data = "b", PercentChanceOfException = 0 }).GetAwaiter().GetResult();
 
-            _logger.LogInformation("Enqueued {Count} ping requests", count);
+            _logger?.LogInformation("Enqueued {Count} ping requests", count);
         } while (!token.IsCancellationRequested);
     }
 
@@ -68,7 +68,7 @@ public class Program
             if (_continuousEnqueueTokenSource.IsCancellationRequested)
                 _continuousEnqueueTokenSource = new CancellationTokenSource();
 
-            _logger.LogWarning("Starting continuous ping...");
+            _logger?.LogWarning("Starting continuous ping...");
             Task.Run(() => EnqueueContinuousPings(25, _continuousEnqueueTokenSource.Token), _continuousEnqueueTokenSource.Token);
         }
         else if (key == ConsoleKey.M)
@@ -81,7 +81,7 @@ public class Program
         }
         else if (key == ConsoleKey.S)
         {
-            _logger.LogWarning("Cancelling continuous ping.");
+            _logger?.LogWarning("Cancelling continuous ping.");
             _continuousEnqueueTokenSource.Cancel();
         }
     }

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -39,6 +39,8 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
     public RedisCacheClient(RedisCacheClientOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
+
         _options = options;
         _timeProvider = options.TimeProvider ?? TimeProvider.System;
         options.Serializer ??= DefaultSerializer.Instance;

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -41,7 +41,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
     public RedisCacheClient(RedisCacheClientOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
+        ArgumentNullException.ThrowIfNull(options?.ConnectionMultiplexer);
 
         _options = options;
         _connectionMultiplexer = options.ConnectionMultiplexer;

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -320,7 +320,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 // Non-existent keys return nil/empty values in their respective positions.
                 // https://redis.io/commands/mget
                 for (int i = 0; i < hashSlotKeys.Length; i++)
-                    result[(string)hashSlotKeys[i]!] = RedisValueToCacheValue<T>(values[i]);
+                    result[hashSlotKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
             }
 
             return result.AsReadOnly();
@@ -332,7 +332,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
             // Redis MGET guarantees that values are returned in the same order as keys
             for (int i = 0; i < redisKeys.Count; i++)
-                result[(string)redisKeys[i]!] = RedisValueToCacheValue<T>(values[i]);
+                result[redisKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
 
             return result.AsReadOnly();
         }
@@ -902,7 +902,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             var result = new Dictionary<string, TimeSpan?>();
             for (int keyIndex = 0; keyIndex < redisKeys.Length; keyIndex++)
             {
-                string key = (string)redisKeys[keyIndex]!;
+                string key = redisKeys[keyIndex].ToString();
                 long ttl = ttls[keyIndex];
                 if (ttl == -2) // Key doesn't exist - omit from result
                     continue;

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -29,13 +29,13 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
     private bool _scriptsLoaded;
     private bool? _supportsMsetEx;
 
-    private LoadedLuaScript _incrementWithExpire = null!;
-    private LoadedLuaScript _removeIfEqual = null!;
-    private LoadedLuaScript _replaceIfEqual = null!;
-    private LoadedLuaScript _setIfHigher = null!;
-    private LoadedLuaScript _setIfLower = null!;
-    private LoadedLuaScript _getAllExpiration = null!;
-    private LoadedLuaScript _setAllExpiration = null!;
+    private LoadedLuaScript? _incrementWithExpire;
+    private LoadedLuaScript? _removeIfEqual;
+    private LoadedLuaScript? _replaceIfEqual;
+    private LoadedLuaScript? _setIfHigher;
+    private LoadedLuaScript? _setIfLower;
+    private LoadedLuaScript? _getAllExpiration;
+    private LoadedLuaScript? _setAllExpiration;
 
     public RedisCacheClient(RedisCacheClientOptions options)
     {
@@ -73,7 +73,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         await LoadScriptsAsync().AnyContext();
 
         var expectedValue = expected.ToRedisValue(_options.Serializer);
-        var redisResult = await Database.ScriptEvaluateAsync(_removeIfEqual, new { key = (RedisKey)key, expected = expectedValue }).AnyContext();
+        var redisResult = await Database.ScriptEvaluateAsync(GetScript(_removeIfEqual), new { key = (RedisKey)key, expected = expectedValue }).AnyContext();
         int result = (int)redisResult;
 
         return result > 0;
@@ -318,7 +318,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 // Non-existent keys return nil/empty values in their respective positions.
                 // https://redis.io/commands/mget
                 for (int i = 0; i < hashSlotKeys.Length; i++)
-                    result[((string?)hashSlotKeys[i])!] = RedisValueToCacheValue<T>(values[i]);
+                    result[hashSlotKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
             }
 
             return result.AsReadOnly();
@@ -330,7 +330,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
             // Redis MGET guarantees that values are returned in the same order as keys
             for (int i = 0; i < redisKeys.Count; i++)
-                result[((string?)redisKeys[i])!] = RedisValueToCacheValue<T>(values[i]);
+                result[redisKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
 
             return result.AsReadOnly();
         }
@@ -516,7 +516,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         var expiresMs = GetExpirationMilliseconds(expiresIn);
         var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
-        var result = await Database.ScriptEvaluateAsync(_setIfHigher, new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_setIfHigher), new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
         return (double)result;
     }
 
@@ -534,7 +534,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         var expiresMs = GetExpirationMilliseconds(expiresIn);
         var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
-        var result = await Database.ScriptEvaluateAsync(_setIfHigher, new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_setIfHigher), new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
         return (long)result;
     }
 
@@ -552,7 +552,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         var expiresMs = GetExpirationMilliseconds(expiresIn);
         var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
-        var result = await Database.ScriptEvaluateAsync(_setIfLower, new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_setIfLower), new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
         return (double)result;
     }
 
@@ -570,7 +570,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         var expiresMs = GetExpirationMilliseconds(expiresIn);
         var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
-        var result = await Database.ScriptEvaluateAsync(_setIfLower, new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_setIfLower), new { key = (RedisKey)key, value, expires = expiresArg }).AnyContext();
         return (long)result;
     }
 
@@ -754,7 +754,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         var expiresMs = GetExpirationMilliseconds(expiresIn);
         var expiresArg = expiresMs.HasValue ? (RedisValue)expiresMs.Value : RedisValue.EmptyString;
-        var redisResult = await Database.ScriptEvaluateAsync(_replaceIfEqual, new { key = (RedisKey)key, value = redisValue, expected = expectedValue, expires = expiresArg }).AnyContext();
+        var redisResult = await Database.ScriptEvaluateAsync(GetScript(_replaceIfEqual), new { key = (RedisKey)key, value = redisValue, expected = expectedValue, expires = expiresArg }).AnyContext();
 
         var result = (int)redisResult;
 
@@ -777,7 +777,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         // Always use Lua script - handles both expiration and TTL removal (null expiration removes TTL)
         await LoadScriptsAsync().AnyContext();
-        var result = await Database.ScriptEvaluateAsync(_incrementWithExpire, new { key = (RedisKey)key, value = amount, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_incrementWithExpire), new { key = (RedisKey)key, value = amount, expires = expiresArg }).AnyContext();
         return (double)result;
     }
 
@@ -797,7 +797,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         // Always use Lua script - handles both expiration and TTL removal (null expiration removes TTL)
         await LoadScriptsAsync().AnyContext();
-        var result = await Database.ScriptEvaluateAsync(_incrementWithExpire, new { key = (RedisKey)key, value = amount, expires = expiresArg }).AnyContext();
+        var result = await Database.ScriptEvaluateAsync(GetScript(_incrementWithExpire), new { key = (RedisKey)key, value = amount, expires = expiresArg }).AnyContext();
         return (long)result;
     }
 
@@ -852,7 +852,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             foreach (var hashSlotGroup in keyList.GroupBy(k => _options.ConnectionMultiplexer.HashSlot(k)))
             {
                 var hashSlotKeys = hashSlotGroup.ToArray();
-                var redisResult = await Database.ScriptEvaluateAsync(_getAllExpiration.Hash, hashSlotKeys).AnyContext();
+                var redisResult = await Database.ScriptEvaluateAsync(GetScript(_getAllExpiration).Hash, hashSlotKeys).AnyContext();
                 if (redisResult.IsNull)
                     continue;
 
@@ -867,7 +867,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
                 for (int hashSlotIndex = 0; hashSlotIndex < hashSlotKeys.Length; hashSlotIndex++)
                 {
-                    string key = ((string?)hashSlotKeys[hashSlotIndex])!;
+                    string key = hashSlotKeys[hashSlotIndex].ToString();
                     long ttl = ttls[hashSlotIndex];
                     if (ttl == -2) // Key doesn't exist - omit from result
                         continue;
@@ -883,7 +883,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         else
         {
             var redisKeys = keyList.ToArray();
-            var redisResult = await Database.ScriptEvaluateAsync(_getAllExpiration.Hash, redisKeys).AnyContext();
+            var redisResult = await Database.ScriptEvaluateAsync(GetScript(_getAllExpiration).Hash, redisKeys).AnyContext();
 
             if (redisResult.IsNull)
                 return ReadOnlyDictionary<string, TimeSpan?>.Empty;
@@ -900,7 +900,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             var result = new Dictionary<string, TimeSpan?>();
             for (int keyIndex = 0; keyIndex < redisKeys.Length; keyIndex++)
             {
-                string key = ((string?)redisKeys[keyIndex])!;
+                string key = redisKeys[keyIndex].ToString();
                 long ttl = ttls[keyIndex];
                 if (ttl == -2) // Key doesn't exist - omit from result
                     continue;
@@ -936,7 +936,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                     .Select(kvp => (RedisValue)(GetExpirationMilliseconds(kvp.Value) ?? -1))
                     .ToArray();
 
-                await Database.ScriptEvaluateAsync(_setAllExpiration.Hash, keys, values).AnyContext();
+                await Database.ScriptEvaluateAsync(GetScript(_setAllExpiration).Hash, keys, values).AnyContext();
             }
         }
         else
@@ -946,7 +946,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 .Select(kvp => (RedisValue)(GetExpirationMilliseconds(kvp.Value) ?? -1))
                 .ToArray();
 
-            await Database.ScriptEvaluateAsync(_setAllExpiration.Hash, keys, values).AnyContext();
+            await Database.ScriptEvaluateAsync(GetScript(_setAllExpiration).Hash, keys, values).AnyContext();
         }
     }
 
@@ -985,6 +985,15 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
             _scriptsLoaded = true;
         }
+
+        if (_incrementWithExpire is null || _removeIfEqual is null || _replaceIfEqual is null ||
+            _setIfHigher is null || _setIfLower is null || _getAllExpiration is null || _setAllExpiration is null)
+            throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
+    }
+
+    private LoadedLuaScript GetScript(LoadedLuaScript? script)
+    {
+        return script ?? throw new InvalidOperationException("Lua scripts not loaded. Call LoadScriptsAsync first.");
     }
 
     private void ConnectionMultiplexerOnConnectionRestored(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -320,7 +320,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 // Non-existent keys return nil/empty values in their respective positions.
                 // https://redis.io/commands/mget
                 for (int i = 0; i < hashSlotKeys.Length; i++)
-                    result[hashSlotKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
+                    result[(string)hashSlotKeys[i]!] = RedisValueToCacheValue<T>(values[i]);
             }
 
             return result.AsReadOnly();
@@ -332,7 +332,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
             // Redis MGET guarantees that values are returned in the same order as keys
             for (int i = 0; i < redisKeys.Count; i++)
-                result[redisKeys[i].ToString()] = RedisValueToCacheValue<T>(values[i]);
+                result[(string)redisKeys[i]!] = RedisValueToCacheValue<T>(values[i]);
 
             return result.AsReadOnly();
         }
@@ -902,7 +902,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             var result = new Dictionary<string, TimeSpan?>();
             for (int keyIndex = 0; keyIndex < redisKeys.Length; keyIndex++)
             {
-                string key = redisKeys[keyIndex].ToString();
+                string key = (string)redisKeys[keyIndex]!;
                 long ttl = ttls[keyIndex];
                 if (ttl == -2) // Key doesn't exist - omit from result
                     continue;

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -41,7 +41,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
     public RedisCacheClient(RedisCacheClientOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(options?.ConnectionMultiplexer);
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
 
         _options = options;
         _connectionMultiplexer = options.ConnectionMultiplexer;
@@ -257,8 +257,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             try
             {
                 var value = redisValue.ToValueOfType<T>(_options.Serializer);
-                if (value is not null)
-                    result.Add(value);
+                result.Add(value!);
             }
             catch (Exception ex)
             {
@@ -282,7 +281,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         try
         {
             var value = redisValue.ToValueOfType<T>(_options.Serializer);
-            return value is not null ? new CacheValue<T>(value, true) : CacheValue<T>.Null;
+            return new CacheValue<T>(value, true);
         }
         catch (Exception ex)
         {

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -29,13 +29,13 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
     private bool _scriptsLoaded;
     private bool? _supportsMsetEx;
 
-    private LoadedLuaScript _incrementWithExpire;
-    private LoadedLuaScript _removeIfEqual;
-    private LoadedLuaScript _replaceIfEqual;
-    private LoadedLuaScript _setIfHigher;
-    private LoadedLuaScript _setIfLower;
-    private LoadedLuaScript _getAllExpiration;
-    private LoadedLuaScript _setAllExpiration;
+    private LoadedLuaScript _incrementWithExpire = null!;
+    private LoadedLuaScript _removeIfEqual = null!;
+    private LoadedLuaScript _replaceIfEqual = null!;
+    private LoadedLuaScript _setIfHigher = null!;
+    private LoadedLuaScript _setIfLower = null!;
+    private LoadedLuaScript _getAllExpiration = null!;
+    private LoadedLuaScript _setAllExpiration = null!;
 
     public RedisCacheClient(RedisCacheClientOptions options)
     {
@@ -77,7 +77,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         return result > 0;
     }
 
-    public async Task<int> RemoveAllAsync(IEnumerable<string> keys = null)
+    public async Task<int> RemoveAllAsync(IEnumerable<string>? keys = null)
     {
         // NOTE: Batch size matches default page size (RedisBase.CursorUtils.DefaultLibraryPageSize)
         int batchSize = 250;
@@ -252,7 +252,8 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             try
             {
                 var value = redisValue.ToValueOfType<T>(_options.Serializer);
-                result.Add(value);
+                if (value is not null)
+                    result.Add(value);
             }
             catch (Exception ex)
             {
@@ -276,7 +277,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         try
         {
             var value = redisValue.ToValueOfType<T>(_options.Serializer);
-            return new CacheValue<T>(value, true);
+            return value is not null ? new CacheValue<T>(value, true) : CacheValue<T>.Null;
         }
         catch (Exception ex)
         {
@@ -315,7 +316,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 // Non-existent keys return nil/empty values in their respective positions.
                 // https://redis.io/commands/mget
                 for (int i = 0; i < hashSlotKeys.Length; i++)
-                    result[hashSlotKeys[i]] = RedisValueToCacheValue<T>(values[i]);
+                    result[((string?)hashSlotKeys[i])!] = RedisValueToCacheValue<T>(values[i]);
             }
 
             return result.AsReadOnly();
@@ -327,13 +328,13 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
             // Redis MGET guarantees that values are returned in the same order as keys
             for (int i = 0; i < redisKeys.Count; i++)
-                result[redisKeys[i]] = RedisValueToCacheValue<T>(values[i]);
+                result[((string?)redisKeys[i])!] = RedisValueToCacheValue<T>(values[i]);
 
             return result.AsReadOnly();
         }
     }
 
-    public async Task<CacheValue<ICollection<T>>> GetListAsync<T>(string key, int? page = null, int pageSize = 100)
+    public async Task<CacheValue<ICollection<T>>> GetListAsync<T>(string key, int? page = null, int pageSize = 100) where T : notnull
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
 
@@ -369,7 +370,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         return InternalSetAsync(key, value, expiresIn, When.NotExists);
     }
 
-    public async Task<long> ListAddAsync<T>(string key, IEnumerable<T> values, TimeSpan? expiresIn = null)
+    public async Task<long> ListAddAsync<T>(string key, IEnumerable<T> values, TimeSpan? expiresIn = null) where T : notnull
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(values);
@@ -402,7 +403,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         return added;
     }
 
-    public async Task<long> ListRemoveAsync<T>(string key, IEnumerable<T> values)
+    public async Task<long> ListRemoveAsync<T>(string key, IEnumerable<T> values) where T : notnull
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(values);
@@ -450,7 +451,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         await SetExpirationAsync(key, expiresIn).AnyContext();
     }
 
-    private async Task RemoveExpiredListValuesAsync<T>(string key, bool isStringValues)
+    private async Task RemoveExpiredListValuesAsync<T>(string key, bool isStringValues) where T : notnull
     {
         try
         {
@@ -468,7 +469,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         }
     }
 
-    private async Task MigrateLegacySetToSortedSetForKeyAsync<T>(string key, bool isStringValues)
+    private async Task MigrateLegacySetToSortedSetForKeyAsync<T>(string key, bool isStringValues) where T : notnull
     {
         // convert legacy set to sorted set
         var oldItems = await Database.SetMembersAsync(key).AnyContext();
@@ -858,13 +859,13 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 //   -2 = Key does not exist
                 //   -1 = Key exists but has no associated expiration
                 //   Positive integer = Remaining TTL in milliseconds
-                long[] ttls = (long[])redisResult;
+                long[]? ttls = (long[]?)redisResult;
                 if (ttls is null || ttls.Length != hashSlotKeys.Length)
                     throw new InvalidOperationException($"Script returned {ttls?.Length ?? 0} results for {hashSlotKeys.Length} keys");
 
                 for (int hashSlotIndex = 0; hashSlotIndex < hashSlotKeys.Length; hashSlotIndex++)
                 {
-                    string key = hashSlotKeys[hashSlotIndex];
+                    string key = ((string?)hashSlotKeys[hashSlotIndex])!;
                     long ttl = ttls[hashSlotIndex];
                     if (ttl == -2) // Key doesn't exist - omit from result
                         continue;
@@ -890,14 +891,14 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             //   -2 = Key does not exist
             //   -1 = Key exists but has no associated expiration
             //   Positive integer = Remaining TTL in milliseconds
-            long[] ttls = (long[])redisResult;
+            long[]? ttls = (long[]?)redisResult;
             if (ttls is null || ttls.Length != redisKeys.Length)
                 throw new InvalidOperationException($"Script returned {ttls?.Length ?? 0} results for {redisKeys.Length} keys");
 
             var result = new Dictionary<string, TimeSpan?>();
             for (int keyIndex = 0; keyIndex < redisKeys.Length; keyIndex++)
             {
-                string key = redisKeys[keyIndex];
+                string key = ((string?)redisKeys[keyIndex])!;
                 long ttl = ttls[keyIndex];
                 if (ttl == -2) // Key doesn't exist - omit from result
                     continue;
@@ -984,14 +985,14 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         }
     }
 
-    private void ConnectionMultiplexerOnConnectionRestored(object sender, ConnectionFailedEventArgs connectionFailedEventArgs)
+    private void ConnectionMultiplexerOnConnectionRestored(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)
     {
         _logger.LogInformation("Redis connection restored");
         _scriptsLoaded = false;
         _supportsMsetEx = null; // Re-check version on next call
     }
 
-    private void ConnectionMultiplexerOnConnectionFailed(object sender, ConnectionFailedEventArgs connectionFailedEventArgs)
+    private void ConnectionMultiplexerOnConnectionFailed(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)
     {
         _logger.LogWarning("Redis connection failed: {FailureType}", connectionFailedEventArgs.FailureType);
     }

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -986,12 +986,12 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 _setAllExpiration = await setAllExpiration.LoadAsync(server).AnyContext();
             }
 
+            if (_incrementWithExpire is null || _removeIfEqual is null || _replaceIfEqual is null ||
+                _setIfHigher is null || _setIfLower is null || _getAllExpiration is null || _setAllExpiration is null)
+                throw new CacheException("Lua scripts could not be loaded: no connected primary Redis server found.");
+
             _scriptsLoaded = true;
         }
-
-        if (_incrementWithExpire is null || _removeIfEqual is null || _replaceIfEqual is null ||
-            _setIfHigher is null || _setIfLower is null || _getAllExpiration is null || _setAllExpiration is null)
-            throw new CacheException("Lua scripts could not be loaded: no connected primary Redis server found.");
     }
 
     private LoadedLuaScript GetScript(LoadedLuaScript? script)

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -19,6 +19,7 @@ namespace Foundatio.Caching;
 public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 {
     private readonly RedisCacheClientOptions _options;
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
     private readonly bool _isCluster;
@@ -39,16 +40,18 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
     public RedisCacheClient(RedisCacheClientOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
 
         _options = options;
+        _connectionMultiplexer = options.ConnectionMultiplexer;
         _timeProvider = options.TimeProvider ?? TimeProvider.System;
         options.Serializer ??= DefaultSerializer.Instance;
         _logger = options.LoggerFactory?.CreateLogger(typeof(RedisCacheClient)) ?? NullLogger.Instance;
 
-        options.ConnectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
-        options.ConnectionMultiplexer.ConnectionFailed += ConnectionMultiplexerOnConnectionFailed;
-        _isCluster = options.ConnectionMultiplexer.IsCluster();
+        _connectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionFailed += ConnectionMultiplexerOnConnectionFailed;
+        _isCluster = _connectionMultiplexer.IsCluster();
     }
 
     public RedisCacheClient(Builder<RedisCacheClientOptionsBuilder, RedisCacheClientOptions> config)
@@ -56,7 +59,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
     {
     }
 
-    public IDatabase Database => _options.ConnectionMultiplexer.GetDatabase(_options.Database);
+    public IDatabase Database => _connectionMultiplexer.GetDatabase(_options.Database);
 
     public Task<bool> RemoveAsync(string key)
     {
@@ -87,13 +90,13 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         long deleted = 0;
         if (keys is null)
         {
-            var endpoints = _options.ConnectionMultiplexer.GetEndPoints();
+            var endpoints = _connectionMultiplexer.GetEndPoints();
             if (endpoints.Length is 0)
                 return 0;
 
             foreach (var endpoint in endpoints)
             {
-                var server = _options.ConnectionMultiplexer.GetServer(endpoint);
+                var server = _connectionMultiplexer.GetServer(endpoint);
                 if (server.IsReplica)
                     continue;
 
@@ -192,7 +195,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         if (String.IsNullOrEmpty(prefix))
             return await RemoveAllAsync().AnyContext();
 
-        var endpoints = _options.ConnectionMultiplexer.GetEndPoints();
+        var endpoints = _connectionMultiplexer.GetEndPoints();
         if (endpoints.Length == 0)
             return 0;
 
@@ -202,7 +205,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         long deleted = 0;
         foreach (var endpoint in endpoints)
         {
-            var server = _options.ConnectionMultiplexer.GetServer(endpoint);
+            var server = _connectionMultiplexer.GetServer(endpoint);
             if (server.IsReplica)
                 continue;
 
@@ -215,7 +218,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
                 if (isCluster)
                 {
                     // NOTE: Consider parallel processing per hash slot for performance optimization
-                    foreach (var slotGroup in keys.GroupBy(k => _options.ConnectionMultiplexer.HashSlot(k)))
+                    foreach (var slotGroup in keys.GroupBy(k => _connectionMultiplexer.HashSlot(k)))
                     {
                         long count = await Database.KeyDeleteAsync(slotGroup.ToArray()).AnyContext();
                         Interlocked.Add(ref deleted, count);
@@ -309,7 +312,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         {
             var result = new Dictionary<string, CacheValue<T>>(redisKeys.Count);
             // NOTE: Consider parallel processing per hash slot for performance optimization
-            foreach (var hashSlotGroup in redisKeys.GroupBy(k => _options.ConnectionMultiplexer.HashSlot(k)))
+            foreach (var hashSlotGroup in redisKeys.GroupBy(k => _connectionMultiplexer.HashSlot(k)))
             {
                 var hashSlotKeys = hashSlotGroup.ToArray();
                 var values = await Database.StringGetAsync(hashSlotKeys, _options.ReadMode).AnyContext();
@@ -620,7 +623,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             // require all keys to be in the same slot
             // NOTE: Consider parallel processing per hash slot for performance optimization
             int successCount = 0;
-            foreach (var slotGroup in pairs.GroupBy(p => _options.ConnectionMultiplexer.HashSlot(p.Key)))
+            foreach (var slotGroup in pairs.GroupBy(p => _connectionMultiplexer.HashSlot(p.Key)))
             {
                 int count = await SetAllInternalAsync(slotGroup.ToArray(), expiresIn).AnyContext();
                 Interlocked.Add(ref successCount, count);
@@ -694,7 +697,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         // Redis 8.4 RC1 is internally versioned as 8.3.224
         var minVersion = new Version(8, 3, 224);
 
-        var endpoints = _options.ConnectionMultiplexer.GetEndPoints();
+        var endpoints = _connectionMultiplexer.GetEndPoints();
         if (endpoints.Length == 0)
         {
             _logger.LogDebug("SupportsMsetexCommand: No endpoints configured, MSETEX not available");
@@ -704,7 +707,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         bool foundConnectedPrimary = false;
         foreach (var endpoint in endpoints)
         {
-            var server = _options.ConnectionMultiplexer.GetServer(endpoint);
+            var server = _connectionMultiplexer.GetServer(endpoint);
             if (server.IsConnected && !server.IsReplica)
             {
                 foundConnectedPrimary = true;
@@ -849,7 +852,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         {
             var result = new Dictionary<string, TimeSpan?>(keyList.Count);
             // NOTE: Consider parallel processing per hash slot for performance optimization
-            foreach (var hashSlotGroup in keyList.GroupBy(k => _options.ConnectionMultiplexer.HashSlot(k)))
+            foreach (var hashSlotGroup in keyList.GroupBy(k => _connectionMultiplexer.HashSlot(k)))
             {
                 var hashSlotKeys = hashSlotGroup.ToArray();
                 var redisResult = await Database.ScriptEvaluateAsync(GetScript(_getAllExpiration).Hash, hashSlotKeys).AnyContext();
@@ -928,7 +931,7 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         if (_isCluster)
         {
             // NOTE: Consider parallel processing per hash slot for performance optimization
-            foreach (var hashSlotGroup in expirations.GroupBy(kvp => _options.ConnectionMultiplexer.HashSlot(kvp.Key)))
+            foreach (var hashSlotGroup in expirations.GroupBy(kvp => _connectionMultiplexer.HashSlot(kvp.Key)))
             {
                 var hashSlotExpirations = hashSlotGroup.ToList();
                 var keys = hashSlotExpirations.Select(kvp => (RedisKey)kvp.Key).ToArray();
@@ -968,9 +971,9 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
             var getAllExpiration = LuaScript.Prepare(GetAllExpirationScript);
             var setAllExpiration = LuaScript.Prepare(SetAllExpirationScript);
 
-            foreach (var endpoint in _options.ConnectionMultiplexer.GetEndPoints())
+            foreach (var endpoint in _connectionMultiplexer.GetEndPoints())
             {
-                var server = _options.ConnectionMultiplexer.GetServer(endpoint);
+                var server = _connectionMultiplexer.GetServer(endpoint);
                 if (server.IsReplica)
                     continue;
 
@@ -988,12 +991,12 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
 
         if (_incrementWithExpire is null || _removeIfEqual is null || _replaceIfEqual is null ||
             _setIfHigher is null || _setIfLower is null || _getAllExpiration is null || _setAllExpiration is null)
-            throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
+            throw new CacheException("Lua scripts could not be loaded: no connected primary Redis server found.");
     }
 
     private LoadedLuaScript GetScript(LoadedLuaScript? script)
     {
-        return script ?? throw new InvalidOperationException("Lua scripts not loaded. Call LoadScriptsAsync first.");
+        return script ?? throw new CacheException("Lua scripts not loaded. Call LoadScriptsAsync first.");
     }
 
     private void ConnectionMultiplexerOnConnectionRestored(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)
@@ -1016,8 +1019,8 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         _isDisposed = true;
         _disposedCancellationTokenSource.Cancel();
         _disposedCancellationTokenSource.Dispose();
-        _options.ConnectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
-        _options.ConnectionMultiplexer.ConnectionFailed -= ConnectionMultiplexerOnConnectionFailed;
+        _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionFailed -= ConnectionMultiplexerOnConnectionFailed;
     }
 
     /// <summary>

--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Caching;
 
 public class RedisCacheClientOptions : SharedOptions
 {
-    public IConnectionMultiplexer? ConnectionMultiplexer { get; set; }
+    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
 
     /// <summary>
     /// Whether or not an error when deserializing a cache value should result in an exception being thrown or if it should just return an empty cache value

--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Caching;
 
 public class RedisCacheClientOptions : SharedOptions
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
+    public IConnectionMultiplexer? ConnectionMultiplexer { get; set; }
 
     /// <summary>
     /// Whether or not an error when deserializing a cache value should result in an exception being thrown or if it should just return an empty cache value

--- a/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClientOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Caching;
 
 public class RedisCacheClientOptions : SharedOptions
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
+    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
 
     /// <summary>
     /// Whether or not an error when deserializing a cache value should result in an exception being thrown or if it should just return an empty cache value

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -11,9 +11,9 @@ public class RedisHybridCacheClient : HybridCacheClient
 
     private static RedisCacheClient CreateCacheClient(RedisHybridCacheClientOptions options)
     {
-        var connectionMultiplexer = options.ConnectionMultiplexer ?? throw new ArgumentNullException(nameof(options), "ConnectionMultiplexer is required.");
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer, nameof(options.ConnectionMultiplexer));
         return new RedisCacheClient(o => o
-            .ConnectionMultiplexer(connectionMultiplexer)
+            .ConnectionMultiplexer(options.ConnectionMultiplexer)
             .Serializer(options.Serializer)
             .LoggerFactory(options.LoggerFactory)
             .ShouldThrowOnSerializationError(options.ShouldThrowOnSerializationError)
@@ -23,9 +23,9 @@ public class RedisHybridCacheClient : HybridCacheClient
 
     private static RedisMessageBus CreateMessageBus(RedisHybridCacheClientOptions options)
     {
-        var connectionMultiplexer = options.ConnectionMultiplexer ?? throw new ArgumentNullException(nameof(options), "ConnectionMultiplexer is required.");
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer, nameof(options.ConnectionMultiplexer));
         return new RedisMessageBus(o => o
-            .Subscriber(connectionMultiplexer.GetSubscriber())
+            .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
             .Topic(options.RedisChannelName)
             .Serializer(options.Serializer)
             .LoggerFactory(options.LoggerFactory));

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -1,22 +1,34 @@
+using System;
 using Foundatio.Messaging;
 namespace Foundatio.Caching;
 
 public class RedisHybridCacheClient : HybridCacheClient
 {
     public RedisHybridCacheClient(RedisHybridCacheClientOptions options, InMemoryCacheClientOptions? localOptions = null)
-        : base(new RedisCacheClient(o => o
-                .ConnectionMultiplexer(options.ConnectionMultiplexer)
-                .Serializer(options.Serializer)
-                .LoggerFactory(options.LoggerFactory)
-                .ShouldThrowOnSerializationError(options.ShouldThrowOnSerializationError)
-                .ReadMode(options.ReadMode)
-                .UseDatabase(options.Database)),
-            new RedisMessageBus(o => o
-                .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
-                .Topic(options.RedisChannelName)
-                .Serializer(options.Serializer)
-                .LoggerFactory(options.LoggerFactory)), localOptions, options.LoggerFactory)
+        : base(CreateCacheClient(options), CreateMessageBus(options), localOptions, options.LoggerFactory)
     {
+    }
+
+    private static RedisCacheClient CreateCacheClient(RedisHybridCacheClientOptions options)
+    {
+        var connectionMultiplexer = options.ConnectionMultiplexer ?? throw new ArgumentNullException(nameof(options), "ConnectionMultiplexer is required.");
+        return new RedisCacheClient(o => o
+            .ConnectionMultiplexer(connectionMultiplexer)
+            .Serializer(options.Serializer)
+            .LoggerFactory(options.LoggerFactory)
+            .ShouldThrowOnSerializationError(options.ShouldThrowOnSerializationError)
+            .ReadMode(options.ReadMode)
+            .UseDatabase(options.Database));
+    }
+
+    private static RedisMessageBus CreateMessageBus(RedisHybridCacheClientOptions options)
+    {
+        var connectionMultiplexer = options.ConnectionMultiplexer ?? throw new ArgumentNullException(nameof(options), "ConnectionMultiplexer is required.");
+        return new RedisMessageBus(o => o
+            .Subscriber(connectionMultiplexer.GetSubscriber())
+            .Topic(options.RedisChannelName)
+            .Serializer(options.Serializer)
+            .LoggerFactory(options.LoggerFactory));
     }
 
     public RedisHybridCacheClient(Builder<RedisHybridCacheClientOptionsBuilder, RedisHybridCacheClientOptions> config,

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -13,6 +13,7 @@ public class RedisHybridCacheClient : HybridCacheClient
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
+
         return new RedisCacheClient(o => o
             .ConnectionMultiplexer(options.ConnectionMultiplexer)
             .Serializer(options.Serializer)
@@ -26,6 +27,7 @@ public class RedisHybridCacheClient : HybridCacheClient
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
+
         return new RedisMessageBus(o => o
             .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
             .Topic(options.RedisChannelName)

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -1,9 +1,9 @@
-﻿using Foundatio.Messaging;
+using Foundatio.Messaging;
 namespace Foundatio.Caching;
 
 public class RedisHybridCacheClient : HybridCacheClient
 {
-    public RedisHybridCacheClient(RedisHybridCacheClientOptions options, InMemoryCacheClientOptions localOptions = null)
+    public RedisHybridCacheClient(RedisHybridCacheClientOptions options, InMemoryCacheClientOptions? localOptions = null)
         : base(new RedisCacheClient(o => o
                 .ConnectionMultiplexer(options.ConnectionMultiplexer)
                 .Serializer(options.Serializer)
@@ -20,7 +20,7 @@ public class RedisHybridCacheClient : HybridCacheClient
     }
 
     public RedisHybridCacheClient(Builder<RedisHybridCacheClientOptionsBuilder, RedisHybridCacheClientOptions> config,
-        Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions> localConfig = null)
+        Builder<InMemoryCacheClientOptionsBuilder, InMemoryCacheClientOptions>? localConfig = null)
         : this(config(new RedisHybridCacheClientOptionsBuilder()).Build(),
             localConfig?.Invoke(new InMemoryCacheClientOptionsBuilder()).Build())
     {

--- a/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisHybridCacheClient.cs
@@ -11,7 +11,8 @@ public class RedisHybridCacheClient : HybridCacheClient
 
     private static RedisCacheClient CreateCacheClient(RedisHybridCacheClientOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer, nameof(options.ConnectionMultiplexer));
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
         return new RedisCacheClient(o => o
             .ConnectionMultiplexer(options.ConnectionMultiplexer)
             .Serializer(options.Serializer)
@@ -23,7 +24,8 @@ public class RedisHybridCacheClient : HybridCacheClient
 
     private static RedisMessageBus CreateMessageBus(RedisHybridCacheClientOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer, nameof(options.ConnectionMultiplexer));
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
         return new RedisMessageBus(o => o
             .Subscriber(options.ConnectionMultiplexer.GetSubscriber())
             .Topic(options.RedisChannelName)

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -41,9 +41,15 @@ internal static class RedisValueExtensions
             return (T)Convert.ChangeType(redisValue, type)!;
 
         if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
-            return (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type)
+                ?? throw new InvalidOperationException($"Expected nullable type but {type.Name} has no underlying type");
+            return (T)Convert.ChangeType(redisValue, underlyingType)!;
+        }
 
-        return serializer.Deserialize<T>(((byte[]?)redisValue)!);
+        byte[] bytes = (byte[]?)redisValue
+            ?? throw new InvalidOperationException($"Expected non-null byte[] from RedisValue for type {typeof(T).Name}");
+        return serializer.Deserialize<T>(bytes);
     }
 
     /// <summary>

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Foundatio.Extensions;
 using Foundatio.Serializer;
 using Foundatio.Utility;
@@ -10,17 +11,18 @@ internal static class RedisValueExtensions
 {
     private static readonly RedisValue _nullValue = "@@NULL";
 
+    [return: MaybeNull]
     public static T ToValueOfType<T>(this RedisValue redisValue, ISerializer serializer)
     {
         T value;
         var type = typeof(T);
 
         if (type == TypeHelper.BoolType || type == TypeHelper.StringType || type.IsNumeric())
-            value = (T)Convert.ChangeType(redisValue, type);
+            value = (T)Convert.ChangeType(redisValue, type)!;
         else if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
-            value = redisValue.IsNull ? default : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type));
+            value = redisValue.IsNull ? default! : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
         else
-            return serializer.Deserialize<T>((byte[])redisValue);
+            return serializer.Deserialize<T>(((byte[]?)redisValue)!);
 
         return value;
     }

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -11,22 +11,30 @@ internal static class RedisValueExtensions
 {
     private static readonly RedisValue _nullValue = "@@NULL";
 
+    /// <summary>
+    /// Converts a <see cref="RedisValue"/> to the specified type <typeparamref name="T"/>.
+    /// Handles primitive types, nullable types, and complex types via serializer.
+    /// </summary>
+    /// <returns>The converted value, or <c>default</c> for null <see cref="RedisValue"/> with nullable target types.</returns>
     [return: MaybeNull]
     public static T ToValueOfType<T>(this RedisValue redisValue, ISerializer serializer)
     {
-        T value;
         var type = typeof(T);
 
         if (type == TypeHelper.BoolType || type == TypeHelper.StringType || type.IsNumeric())
-            value = (T)Convert.ChangeType(redisValue, type)!;
-        else if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
-            value = redisValue.IsNull ? default! : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
-        else
-            return serializer.Deserialize<T>(((byte[]?)redisValue)!);
+            return (T)Convert.ChangeType(redisValue, type)!;
 
-        return value;
+        if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
+            return redisValue.IsNull ? default! : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
+
+        return serializer.Deserialize<T>(((byte[]?)redisValue)!);
     }
 
+    /// <summary>
+    /// Converts a value of type <typeparamref name="T"/> to a <see cref="RedisValue"/>.
+    /// Null values are stored as a sentinel string ("@@NULL") to distinguish from missing keys.
+    /// Handles primitive types directly and falls back to the serializer for complex types.
+    /// </summary>
     public static RedisValue ToRedisValue<T>(this T value, ISerializer serializer)
     {
         var redisValue = _nullValue;

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -13,19 +13,35 @@ internal static class RedisValueExtensions
 
     /// <summary>
     /// Converts a <see cref="RedisValue"/> to the specified type <typeparamref name="T"/>.
-    /// Handles primitive types, nullable types, and complex types via serializer.
+    /// Handles null/empty Redis values, primitive types (bool, string, numeric), nullable
+    /// numeric types, and falls back to the <paramref name="serializer"/> for complex types.
+    /// Follows the same conversion strategy as <c>TypeExtensions.ToType&lt;T&gt;</c> in Foundatio core.
     /// </summary>
-    /// <returns>The converted value, or <c>default</c> for null <see cref="RedisValue"/> with nullable target types.</returns>
+    /// <typeparam name="T">The target type to convert to.</typeparam>
+    /// <param name="redisValue">The Redis value to convert.</param>
+    /// <param name="serializer">Serializer used for complex (non-primitive) types.</param>
+    /// <returns>
+    /// The converted value, or <c>default</c> when <paramref name="redisValue"/> is null/empty
+    /// and <typeparamref name="T"/> is a reference or nullable type.
+    /// </returns>
     [return: MaybeNull]
     public static T ToValueOfType<T>(this RedisValue redisValue, ISerializer serializer)
     {
+        if (redisValue.IsNull)
+        {
+            if (!typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) is not null)
+                return default!;
+
+            return default!;
+        }
+
         var type = typeof(T);
 
         if (type == TypeHelper.BoolType || type == TypeHelper.StringType || type.IsNumeric())
             return (T)Convert.ChangeType(redisValue, type)!;
 
         if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
-            return redisValue.IsNull ? default! : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
+            return (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!)!;
 
         return serializer.Deserialize<T>(((byte[]?)redisValue)!);
     }

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -32,7 +32,7 @@ internal static class RedisValueExtensions
             if (!typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) is not null)
                 return default!;
 
-            throw new ArgumentNullException(nameof(redisValue));
+            throw new InvalidOperationException($"Cannot convert null Redis value to non-nullable type {typeof(T).Name}");
         }
 
         var type = typeof(T);

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -13,43 +13,24 @@ internal static class RedisValueExtensions
 
     /// <summary>
     /// Converts a <see cref="RedisValue"/> to the specified type <typeparamref name="T"/>.
-    /// Handles null/empty Redis values, primitive types (bool, string, numeric), nullable
+    /// Handles null Redis values, primitive types (bool, string, numeric), nullable
     /// numeric types, and falls back to the <paramref name="serializer"/> for complex types.
     /// Follows the same conversion strategy as <c>TypeExtensions.ToType&lt;T&gt;</c> in Foundatio core.
     /// </summary>
-    /// <typeparam name="T">The target type to convert to.</typeparam>
-    /// <param name="redisValue">The Redis value to convert.</param>
-    /// <param name="serializer">Serializer used for complex (non-primitive) types.</param>
-    /// <returns>
-    /// The converted value, or <c>default</c> when <paramref name="redisValue"/> is null/empty
-    /// and <typeparamref name="T"/> is a reference or nullable type.
-    /// </returns>
     [return: MaybeNull]
     public static T ToValueOfType<T>(this RedisValue redisValue, ISerializer serializer)
     {
-        if (redisValue.IsNull)
-        {
-            if (!typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) is not null)
-                return default!;
-
-            throw new InvalidOperationException($"Cannot convert null Redis value to non-nullable type {typeof(T).Name}");
-        }
-
+        T value;
         var type = typeof(T);
 
         if (type == TypeHelper.BoolType || type == TypeHelper.StringType || type.IsNumeric())
-            return (T)Convert.ChangeType(redisValue, type)!;
+            value = (T)Convert.ChangeType(redisValue, type);
+        else if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
+            value = redisValue.IsNull ? default! : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type)!);
+        else
+            return serializer.Deserialize<T>((byte[])redisValue!);
 
-        if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
-        {
-            var underlyingType = Nullable.GetUnderlyingType(type)
-                ?? throw new InvalidOperationException($"Expected nullable type but {type.Name} has no underlying type");
-            return (T)Convert.ChangeType(redisValue, underlyingType)!;
-        }
-
-        byte[] bytes = (byte[]?)redisValue
-            ?? throw new InvalidOperationException($"Expected non-null byte[] from RedisValue for type {typeof(T).Name}");
-        return serializer.Deserialize<T>(bytes);
+        return value;
     }
 
     /// <summary>

--- a/src/Foundatio.Redis/Extensions/RedisExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisExtensions.cs
@@ -32,7 +32,7 @@ internal static class RedisValueExtensions
             if (!typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) is not null)
                 return default!;
 
-            return default!;
+            throw new ArgumentNullException(nameof(redisValue));
         }
 
         var type = typeof(T);

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.42" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.48" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.42" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.48" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -15,6 +15,7 @@ namespace Foundatio.Messaging;
 public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 {
     private readonly AsyncLock _lock = new();
+    private readonly ISubscriber _subscriber;
     private bool _isSubscribed;
     private ChannelMessageQueue? _channelMessageQueue;
     private readonly RedisChannel _channel;
@@ -23,6 +24,8 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
     {
         ArgumentNullException.ThrowIfNull(options.Subscriber);
         ArgumentException.ThrowIfNullOrEmpty(options.Topic);
+
+        _subscriber = options.Subscriber;
 
         // In Redis Cluster mode, use sharded pub/sub (SPUBLISH/SSUBSCRIBE) to avoid duplicate
         // message delivery caused by cluster-wide broadcast. Regular PUBLISH in a cluster
@@ -36,7 +39,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         // Falls back to standard PUBLISH/SUBSCRIBE for standalone, sentinel, and proxy deployments.
         // See: https://redis.io/docs/latest/commands/spublish/
         // See: https://redis.io/docs/latest/commands/ssubscribe/
-        _channel = options.Subscriber.Multiplexer.IsCluster()
+        _channel = _subscriber.Multiplexer.IsCluster()
             ? RedisChannel.Sharded(options.Topic)
             : RedisChannel.Literal(options.Topic);
     }
@@ -57,7 +60,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
                 return;
 
             _logger.LogTrace("Subscribing to topic: {Topic}", _options.Topic);
-            _channelMessageQueue = await _options.Subscriber.SubscribeAsync(_channel).AnyContext();
+            _channelMessageQueue = await _subscriber.SubscribeAsync(_channel).AnyContext();
             _channelMessageQueue.OnMessage(OnMessage);
             _isSubscribed = true;
             _logger.LogTrace("Subscribed to topic: {Topic}", _options.Topic);
@@ -79,7 +82,8 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         IMessage message;
         try
         {
-            var envelope = _serializer.Deserialize<RedisMessageEnvelope>(((byte[]?)channelMessage.Message)!);
+            byte[] messageBytes = (byte[]?)channelMessage.Message ?? [];
+            var envelope = _serializer.Deserialize<RedisMessageEnvelope>(messageBytes);
             if (envelope is null)
             {
                 _logger.LogWarning("OnMessage({Channel}) Deserialized envelope was null", channelMessage.Channel);
@@ -152,7 +156,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         // TODO: Use ILockProvider to lock on UniqueId to ensure it doesn't get duplicated
         // Wrap only the transport call in resilience policy
         await _resiliencePolicy.ExecuteAsync(async _ =>
-            await _options.Subscriber.PublishAsync(_channel, data, CommandFlags.FireAndForget),
+            await _subscriber.PublishAsync(_channel, data, CommandFlags.FireAndForget),
             cancellationToken).AnyContext();
     }
 

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -95,7 +95,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
             message = new Message(envelope.Data ?? [], DeserializeMessageBody)
             {
-                Type = envelope.Type ?? String.Empty,
+                Type = envelope.Type,
                 ClrType = envelope.Type is not null ? GetMappedMessageType(envelope.Type) : null,
                 CorrelationId = envelope.CorrelationId,
                 UniqueId = envelope.UniqueId

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -86,6 +86,9 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
                 return;
             }
 
+            if (envelope.Data is null || envelope.Type is null)
+                _logger.LogWarning("OnMessage({Channel}) Envelope has null {Field}, treating as empty", channelMessage.Channel, envelope.Data is null ? "Data" : "Type");
+
             message = new Message(envelope.Data ?? [], DeserializeMessageBody)
             {
                 Type = envelope.Type ?? string.Empty,

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -91,7 +91,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
             message = new Message(envelope.Data ?? [], DeserializeMessageBody)
             {
-                Type = envelope.Type ?? string.Empty,
+                Type = envelope.Type ?? String.Empty,
                 ClrType = envelope.Type is not null ? GetMappedMessageType(envelope.Type) : null,
                 CorrelationId = envelope.CorrelationId,
                 UniqueId = envelope.UniqueId

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -86,7 +86,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
                 return;
             }
 
-            message = new Message(envelope.Data, DeserializeMessageBody)
+            message = new Message(envelope.Data ?? [], DeserializeMessageBody)
             {
                 Type = envelope.Type ?? string.Empty,
                 ClrType = envelope.Type is not null ? GetMappedMessageType(envelope.Type) : null,
@@ -94,8 +94,11 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
                 UniqueId = envelope.UniqueId
             };
 
-            foreach (var property in envelope.Properties)
-                message.Properties.Add(property.Key, property.Value);
+            if (envelope.Properties is not null)
+            {
+                foreach (var property in envelope.Properties)
+                    message.Properties.Add(property.Key, property.Value);
+            }
         }
         catch (Exception ex)
         {
@@ -183,6 +186,6 @@ public class RedisMessageEnvelope
     public string? UniqueId { get; set; }
     public string? CorrelationId { get; set; }
     public string? Type { get; set; }
-    public byte[] Data { get; set; } = null!;
-    public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+    public byte[]? Data { get; set; }
+    public Dictionary<string, string>? Properties { get; set; } = new Dictionary<string, string>();
 }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -86,7 +86,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
             var envelope = _serializer.Deserialize<RedisMessageEnvelope>(messageBytes);
             if (envelope is null)
             {
-                _logger.LogWarning("OnMessage({Channel}) Deserialized envelope was null", channelMessage.Channel);
+                _logger.LogError("OnMessage({Channel}) Deserialized envelope was null", channelMessage.Channel);
                 return;
             }
 
@@ -96,7 +96,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
             message = new Message(envelope.Data ?? [], DeserializeMessageBody)
             {
                 Type = envelope.Type,
-                ClrType = envelope.Type is not null ? GetMappedMessageType(envelope.Type) : null,
+                ClrType = GetMappedMessageType(envelope.Type),
                 CorrelationId = envelope.CorrelationId,
                 UniqueId = envelope.UniqueId
             };
@@ -133,8 +133,8 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
     {
         if (options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
-            var mappedType = GetMappedMessageType(messageType);
             _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            var mappedType = GetMappedMessageType(messageType);
             if (mappedType is null)
                 throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
 

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -133,11 +133,11 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
     {
         if (options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
-            _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
             var mappedType = GetMappedMessageType(messageType);
             if (mappedType is null)
                 throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
 
+            _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
             SendDelayedMessage(mappedType, message, options);
             return;
         }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -16,7 +16,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 {
     private readonly AsyncLock _lock = new();
     private bool _isSubscribed;
-    private ChannelMessageQueue _channelMessageQueue;
+    private ChannelMessageQueue? _channelMessageQueue;
     private readonly RedisChannel _channel;
 
     public RedisMessageBus(RedisMessageBusOptions options) : base(options)
@@ -79,11 +79,17 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         IMessage message;
         try
         {
-            var envelope = _serializer.Deserialize<RedisMessageEnvelope>((byte[])channelMessage.Message);
+            var envelope = _serializer.Deserialize<RedisMessageEnvelope>(((byte[]?)channelMessage.Message)!);
+            if (envelope is null)
+            {
+                _logger.LogWarning("OnMessage({Channel}) Deserialized envelope was null", channelMessage.Channel);
+                return;
+            }
+
             message = new Message(envelope.Data, DeserializeMessageBody)
             {
-                Type = envelope.Type,
-                ClrType = GetMappedMessageType(envelope.Type),
+                Type = envelope.Type ?? string.Empty,
+                ClrType = envelope.Type is not null ? GetMappedMessageType(envelope.Type) : null,
                 CorrelationId = envelope.CorrelationId,
                 UniqueId = envelope.UniqueId
             };
@@ -115,10 +121,13 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
     protected override async Task PublishImplAsync(string messageType, object message, MessageOptions options, CancellationToken cancellationToken)
     {
-        var mappedType = GetMappedMessageType(messageType);
         if (options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
+            var mappedType = GetMappedMessageType(messageType);
             _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            if (mappedType is null)
+                throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
+
             SendDelayedMessage(mappedType, message, options);
             return;
         }
@@ -171,9 +180,9 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
 public class RedisMessageEnvelope
 {
-    public string UniqueId { get; set; }
-    public string CorrelationId { get; set; }
-    public string Type { get; set; }
-    public byte[] Data { get; set; }
+    public string? UniqueId { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? Type { get; set; }
+    public byte[] Data { get; set; } = null!;
     public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
 }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Messaging;
 
 public class RedisMessageBusOptions : SharedMessageBusOptions
 {
-    public ISubscriber? Subscriber { get; set; }
+    public ISubscriber Subscriber { get; set; } = null!;
 }
 
 public class RedisMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<RedisMessageBusOptions, RedisMessageBusOptionsBuilder>

--- a/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Messaging;
 
 public class RedisMessageBusOptions : SharedMessageBusOptions
 {
-    public ISubscriber Subscriber { get; set; } = null!;
+    public ISubscriber? Subscriber { get; set; }
 }
 
 public class RedisMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<RedisMessageBusOptions, RedisMessageBusOptionsBuilder>

--- a/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBusOptions.cs
@@ -1,10 +1,10 @@
-﻿using StackExchange.Redis;
+using StackExchange.Redis;
 
 namespace Foundatio.Messaging;
 
 public class RedisMessageBusOptions : SharedMessageBusOptions
 {
-    public ISubscriber Subscriber { get; set; }
+    public ISubscriber Subscriber { get; set; } = null!;
 }
 
 public class RedisMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<RedisMessageBusOptions, RedisMessageBusOptionsBuilder>

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -374,7 +374,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>(value!, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>(value!, null, null, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -431,7 +431,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                     now,
                     timeout = timeout.TotalMilliseconds
                 }).AnyContext();
-                return result.ToString();
+                return (RedisValue)result;
             }, linkedCancellationToken).AnyContext();
         }
         catch (Exception ex)

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -352,9 +352,10 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         if (value.IsNullOrEmpty)
             return null;
 
+        string workId = value.ToString();
         try
         {
-            var entry = await GetQueueEntryAsync(value!).AnyContext();
+            var entry = await GetQueueEntryAsync(workId).AnyContext();
             if (entry is null)
                 return null;
 
@@ -374,7 +375,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>(value!, null, null, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>(workId, null, null, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -599,7 +600,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
         var tasks = new List<Task>(itemIds.Length + 1);
         foreach (var id in itemIds)
-            tasks.Add(DeleteIdKeysAsync(id!));
+            tasks.Add(DeleteIdKeysAsync(id.ToString()));
 
         tasks.Add(Database.KeyDeleteAsync(name));
         await Task.WhenAll(tasks).AnyContext();
@@ -630,7 +631,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         foreach (var id in itemIds)
         {
             tasks.AddRange([
-                DeleteIdKeysAsync(id!),
+                DeleteIdKeysAsync(id.ToString()),
                 Database.ListRemoveAsync(_queueListName, id),
                 Database.ListRemoveAsync(_workListName, id),
                 Database.ListRemoveAsync(_waitListName, id),
@@ -670,7 +671,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 if (DisposedCancellationToken.IsCancellationRequested)
                     return;
 
-                var renewedTimeTicks = await _cache.GetAsync<long>(GetRenewedTimeKey(workId!)).AnyContext();
+                var renewedTimeTicks = await _cache.GetAsync<long>(GetRenewedTimeKey(workId.ToString())).AnyContext();
                 if (!renewedTimeTicks.HasValue)
                 {
                     _logger.LogTrace("Skipping {WorkId}: no renewed time", workId);
@@ -684,7 +685,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                     continue;
 
                 _logger.LogInformation("{WorkId} Auto abandon item. Renewed: {RenewedTime:o} Current: {UtcNow:o} Timeout: {WorkItemTimeout:g} QueueId: {QueueId}", workId, renewedTime, utcNow, _options.WorkItemTimeout, QueueId);
-                var entry = await GetQueueEntryAsync(workId!).AnyContext();
+                var entry = await GetQueueEntryAsync(workId.ToString()).AnyContext();
                 if (entry == null)
                 {
                     _logger.LogError("{WorkId} Error getting queue entry for work item timeout", workId);
@@ -712,7 +713,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 if (DisposedCancellationToken.IsCancellationRequested)
                     return;
 
-                var waitTimeTicks = await _cache.GetAsync<long>(GetWaitTimeKey(waitId!)).AnyContext();
+                var waitTimeTicks = await _cache.GetAsync<long>(GetWaitTimeKey(waitId.ToString())).AnyContext();
                 _logger.LogTrace("{WaitId}: Wait time {WaitTime}", waitId, waitTimeTicks);
 
                 if (waitTimeTicks.HasValue && waitTimeTicks.Value > utcNow.Ticks)
@@ -724,7 +725,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 var tx = Database.CreateTransaction();
                 tx.ListRemoveAsync(_waitListName, waitId);
                 tx.ListLeftPushAsync(_queueListName, waitId);
-                tx.KeyDeleteAsync(GetWaitTimeKey(waitId!));
+                tx.KeyDeleteAsync(GetWaitTimeKey(waitId.ToString()));
                 bool success = await _resiliencePolicy.ExecuteAsync(async _ => await tx.ExecuteAsync()).AnyContext();
                 if (!success)
                     throw new Exception("Unable to move item to queue list.");

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -40,8 +40,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
     public RedisQueue(RedisQueueOptions<T> options) : base(options)
     {
-        if (options.ConnectionMultiplexer == null)
-            throw new ArgumentException("ConnectionMultiplexer is required.");
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
 
         options.ConnectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
 

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -21,6 +21,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     private readonly AsyncLock _lock = new();
     private readonly AsyncAutoResetEvent _autoResetEvent = new();
     private readonly ISubscriber _subscriber;
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisCacheClient _cache;
     private long _enqueuedCount;
     private long _dequeuedCount;
@@ -41,15 +42,16 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     public RedisQueue(RedisQueueOptions<T> options) : base(options)
     {
         ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
+        _connectionMultiplexer = options.ConnectionMultiplexer;
 
-        options.ConnectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
 
-        _cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = options.ConnectionMultiplexer, Serializer = _serializer, ReadMode = options.ReadMode, Database = options.Database });
+        _cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = _connectionMultiplexer, Serializer = _serializer, ReadMode = options.ReadMode, Database = options.Database });
 
         _payloadTimeToLive = GetPayloadTtl();
-        _subscriber = _options.ConnectionMultiplexer.GetSubscriber();
+        _subscriber = _connectionMultiplexer.GetSubscriber();
 
-        bool isCluster = _options.ConnectionMultiplexer.IsCluster();
+        bool isCluster = _connectionMultiplexer.IsCluster();
         _listPrefix = isCluster ? "{q:" + _options.Name + "}" : $"q:{_options.Name}";
         _queueListName = $"{_listPrefix}:in";
         _workListName = $"{_listPrefix}:work";
@@ -71,7 +73,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     {
     }
 
-    public IDatabase Database => _options.ConnectionMultiplexer.GetDatabase(_options.Database);
+    public IDatabase Database => _connectionMultiplexer.GetDatabase(_options.Database);
 
     protected override Task EnsureQueueCreatedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
@@ -218,7 +220,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         };
         bool success = await _resiliencePolicy.ExecuteAsync(async _ => await _cache.AddAsync(GetPayloadKey(id), envelope, _payloadTimeToLive)).AnyContext();
         if (!success)
-            throw new InvalidOperationException("Attempt to set payload failed.");
+            throw new QueueException("Attempt to set payload failed.");
 
         await _resiliencePolicy.ExecuteAsync(async _ => await Task.WhenAll(
             _cache.SetAsync(GetEnqueuedTimeKey(id), now.Ticks, _payloadTimeToLive),
@@ -352,7 +354,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
         try
         {
-            var entry = await GetQueueEntryAsync(value.ToString()).AnyContext();
+            var entry = await GetQueueEntryAsync(value!).AnyContext();
             if (entry is null)
                 return null;
 
@@ -446,14 +448,14 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         if (entry.IsAbandoned || entry.IsCompleted)
         {
             //_logger.LogDebug("Queue {QueueName} item already abandoned or completed: {QueueEntryId}", _options.Name, entry.Id);
-            throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
+            throw new QueueException("Queue entry has already been completed or abandoned.");
         }
 
         long result = await _resiliencePolicy.ExecuteAsync(async _ => await Database.ListRemoveAsync(_workListName, entry.Id)).AnyContext();
         if (result == 0)
         {
             _logger.LogDebug("Queue {QueueName} item not in work list: {QueueEntryId}", _options.Name, entry.Id);
-            throw new InvalidOperationException("Queue entry not in work list, it may have been auto abandoned.");
+            throw new QueueException("Queue entry not in work list, it may have been auto abandoned.");
         }
 
         await _resiliencePolicy.ExecuteAsync(async _ => await DeleteIdKeysAsync(entry.Id)).AnyContext();
@@ -469,7 +471,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         if (entry.IsAbandoned || entry.IsCompleted)
         {
             _logger.LogError("Queue {QueueName}:{QueueId} unable to abandon item because already abandoned or completed: {QueueEntryId}", _options.Name, QueueId, entry.Id);
-            throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
+            throw new QueueException("Queue entry has already been completed or abandoned.");
         }
 
         string attemptsCacheKey = GetAttemptsKey(entry.Id);
@@ -506,7 +508,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
             tx.KeyDeleteAsync(GetRenewedTimeKey(entry.Id));
             bool success = await _resiliencePolicy.ExecuteAsync(async _ => await tx.ExecuteAsync()).AnyContext();
             if (!success)
-                throw new InvalidOperationException("Queue entry not in work list, it may have been auto abandoned.");
+                throw new QueueException("Queue entry not in work list, it may have been auto abandoned.");
 
             await _resiliencePolicy.ExecuteAsync(async _ => await Database.KeyDeleteAsync(GetDequeuedTimeKey(entry.Id))).AnyContext();
         }
@@ -523,7 +525,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
             tx.KeyDeleteAsync(GetRenewedTimeKey(entry.Id));
             bool success = await _resiliencePolicy.ExecuteAsync(async _ => await tx.ExecuteAsync()).AnyContext();
             if (!success)
-                throw new InvalidOperationException("Queue entry not in work list, it may have been auto abandoned.");
+                throw new QueueException("Queue entry not in work list, it may have been auto abandoned.");
 
             await _resiliencePolicy.ExecuteAsync(async _ => await Task.WhenAll(
                 Database.KeyDeleteAsync(GetDequeuedTimeKey(entry.Id)),
@@ -551,7 +553,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         tx.KeyExpireAsync(GetPayloadKey(entry.Id), _options.DeadLetterTimeToLive);
         bool success = await _resiliencePolicy.ExecuteAsync(async _ => await tx.ExecuteAsync()).AnyContext();
         if (!success)
-            throw new InvalidOperationException("Queue entry not in work list, it may have been auto abandoned.");
+            throw new QueueException("Queue entry not in work list, it may have been auto abandoned.");
 
         await _resiliencePolicy.ExecuteAsync(async _ => await Task.WhenAll(
             Database.KeyDeleteAsync(GetDequeuedTimeKey(entry.Id)),
@@ -778,9 +780,9 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
             var dequeueId = LuaScript.Prepare(DequeueIdScript);
 
-            foreach (var endpoint in _options.ConnectionMultiplexer.GetEndPoints())
+            foreach (var endpoint in _connectionMultiplexer.GetEndPoints())
             {
-                var server = _options.ConnectionMultiplexer.GetServer(endpoint);
+                var server = _connectionMultiplexer.GetServer(endpoint);
                 if (server.IsReplica)
                     continue;
 
@@ -797,7 +799,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     public override void Dispose()
     {
         base.Dispose();
-        _options.ConnectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
 
         if (_isSubscribed)
         {

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -790,7 +790,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
             }
 
             if (_dequeueId is null)
-                throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
+                throw new QueueException("Lua scripts could not be loaded: no connected primary Redis server found.");
 
             _scriptsLoaded = true;
         }

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -373,7 +373,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>((string?)value ?? string.Empty, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>((string?)value ?? String.Empty, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -872,9 +872,9 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     private static readonly string DequeueIdScript = EmbeddedResourceLoader.GetEmbeddedResource("Foundatio.Redis.Scripts.DequeueId.lua");
 }
 
-public class RedisPayloadEnvelope<T>
+public record RedisPayloadEnvelope<T>
 {
-    public string? CorrelationId { get; set; }
-    public IDictionary<string, string>? Properties { get; set; }
-    public T Value { get; set; } = default!;
+    public string? CorrelationId { get; init; }
+    public IDictionary<string, string>? Properties { get; init; }
+    public required T Value { get; init; }
 }

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -787,11 +787,11 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 _dequeueId = await dequeueId.LoadAsync(server).AnyContext();
             }
 
+            if (_dequeueId is null)
+                throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
+
             _scriptsLoaded = true;
         }
-
-        if (_dequeueId is null)
-            throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
     }
 
     public override void Dispose()

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -353,7 +353,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
         try
         {
-            var entry = await GetQueueEntryAsync(((string?)value)!).AnyContext();
+            var entry = await GetQueueEntryAsync(value.ToString()).AnyContext();
             if (entry is null)
                 return null;
 

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -36,7 +36,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     private readonly string _listPrefix;
     private readonly RedisChannel _topicChannel;
 
-    private LoadedLuaScript _dequeueId = null!;
+    private LoadedLuaScript? _dequeueId;
 
     public RedisQueue(RedisQueueOptions<T> options) : base(options)
     {
@@ -372,7 +372,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>((string?)value ?? String.Empty, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>(value.ToString(), null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -421,7 +421,8 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 long now = _timeProvider.GetUtcNow().Ticks;
 
                 await LoadScriptsAsync().AnyContext();
-                var result = await Database.ScriptEvaluateAsync(_dequeueId, new
+                var dequeueId = _dequeueId ?? throw new InvalidOperationException("Dequeue script not loaded.");
+                var result = await Database.ScriptEvaluateAsync(dequeueId, new
                 {
                     queueListName = (RedisKey)_queueListName,
                     workListName = (RedisKey)_workListName,
@@ -788,6 +789,9 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
             _scriptsLoaded = true;
         }
+
+        if (_dequeueId is null)
+            throw new InvalidOperationException("Lua scripts could not be loaded: no connected primary Redis server found.");
     }
 
     public override void Dispose()

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -374,7 +374,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>(value.ToString(), null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>(value!, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -423,8 +423,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 long now = _timeProvider.GetUtcNow().Ticks;
 
                 await LoadScriptsAsync().AnyContext();
-                var dequeueId = _dequeueId ?? throw new InvalidOperationException("Dequeue script not loaded.");
-                var result = await Database.ScriptEvaluateAsync(dequeueId, new
+                var result = await Database.ScriptEvaluateAsync(GetScript(_dequeueId), new
                 {
                     queueListName = (RedisKey)_queueListName,
                     workListName = (RedisKey)_workListName,
@@ -794,6 +793,11 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
             _scriptsLoaded = true;
         }
+    }
+
+    private LoadedLuaScript GetScript(LoadedLuaScript? script)
+    {
+        return script ?? throw new QueueException("Lua scripts not loaded. Call LoadScriptsAsync first.");
     }
 
     public override void Dispose()

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -29,14 +29,14 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     private long _workerErrorCount;
     private long _workItemTimeoutCount;
     private readonly ILockProvider _maintenanceLockProvider;
-    private Task _maintenanceTask;
+    private Task? _maintenanceTask;
     private bool _isSubscribed;
     private readonly TimeSpan _payloadTimeToLive;
     private bool _scriptsLoaded;
     private readonly string _listPrefix;
     private readonly RedisChannel _topicChannel;
 
-    private LoadedLuaScript _dequeueId;
+    private LoadedLuaScript _dequeueId = null!;
 
     public RedisQueue(RedisQueueOptions<T> options) : base(options)
     {
@@ -196,7 +196,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         return String.Concat(_listPrefix, ":in");
     }
 
-    protected override async Task<string> EnqueueImplAsync(T data, QueueEntryOptions options)
+    protected override async Task<string?> EnqueueImplAsync(T data, QueueEntryOptions options)
     {
         string id = Guid.NewGuid().ToString("N");
         _logger.LogDebug("Queue {QueueName} enqueue item: {QueueEntryId}", _options.Name, id);
@@ -262,7 +262,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
             {
                 _logger.LogTrace("WorkerLoop Signaled {QueueName}", _options.Name);
 
-                IQueueEntry<T> queueEntry = null;
+                IQueueEntry<T>? queueEntry = null;
                 try
                 {
                     queueEntry = await DequeueImplAsync(linkedCancellationTokenSource.Token).AnyContext();
@@ -314,7 +314,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         }, linkedCancellationTokenSource.Token).ContinueWith(_ => linkedCancellationTokenSource.Dispose()));
     }
 
-    protected override async Task<IQueueEntry<T>> DequeueImplAsync(CancellationToken linkedCancellationToken)
+    protected override async Task<IQueueEntry<T>?> DequeueImplAsync(CancellationToken linkedCancellationToken)
     {
         _logger.LogTrace("Queue {QueueName} dequeuing item...", _options.Name);
 
@@ -353,7 +353,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
         try
         {
-            var entry = await GetQueueEntryAsync(value).AnyContext();
+            var entry = await GetQueueEntryAsync(((string?)value)!).AnyContext();
             if (entry is null)
                 return null;
 
@@ -373,7 +373,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing queue entry payload: {WorkId}, abandoning for retry", value);
-            var poisonEntry = new QueueEntry<T>(value, null, default, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
+            var poisonEntry = new QueueEntry<T>((string?)value ?? string.Empty, null, default!, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -387,7 +387,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         _logger.LogTrace("Renew lock done: {QueueEntryId}", entry.Id);
     }
 
-    private async Task<QueueEntry<T>> GetQueueEntryAsync(string workId)
+    private async Task<QueueEntry<T>?> GetQueueEntryAsync(string workId)
     {
         var payload = await _resiliencePolicy.ExecuteAsync(async _ => await _cache.GetAsync<RedisPayloadEnvelope<T>>(GetPayloadKey(workId))).AnyContext();
         if (payload.IsNull)
@@ -598,7 +598,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
         var tasks = new List<Task>(itemIds.Length + 1);
         foreach (var id in itemIds)
-            tasks.Add(DeleteIdKeysAsync(id));
+            tasks.Add(DeleteIdKeysAsync(id!));
 
         tasks.Add(Database.KeyDeleteAsync(name));
         await Task.WhenAll(tasks).AnyContext();
@@ -629,7 +629,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         foreach (var id in itemIds)
         {
             tasks.AddRange([
-                DeleteIdKeysAsync(id),
+                DeleteIdKeysAsync(id!),
                 Database.ListRemoveAsync(_queueListName, id),
                 Database.ListRemoveAsync(_workListName, id),
                 Database.ListRemoveAsync(_waitListName, id),
@@ -646,7 +646,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         _autoResetEvent.Set();
     }
 
-    private void ConnectionMultiplexerOnConnectionRestored(object sender, ConnectionFailedEventArgs connectionFailedEventArgs)
+    private void ConnectionMultiplexerOnConnectionRestored(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)
     {
         _logger.LogInformation("Redis connection restored");
         _scriptsLoaded = false;
@@ -669,7 +669,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 if (DisposedCancellationToken.IsCancellationRequested)
                     return;
 
-                var renewedTimeTicks = await _cache.GetAsync<long>(GetRenewedTimeKey(workId)).AnyContext();
+                var renewedTimeTicks = await _cache.GetAsync<long>(GetRenewedTimeKey(workId!)).AnyContext();
                 if (!renewedTimeTicks.HasValue)
                 {
                     _logger.LogTrace("Skipping {WorkId}: no renewed time", workId);
@@ -683,7 +683,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                     continue;
 
                 _logger.LogInformation("{WorkId} Auto abandon item. Renewed: {RenewedTime:o} Current: {UtcNow:o} Timeout: {WorkItemTimeout:g} QueueId: {QueueId}", workId, renewedTime, utcNow, _options.WorkItemTimeout, QueueId);
-                var entry = await GetQueueEntryAsync(workId).AnyContext();
+                var entry = await GetQueueEntryAsync(workId!).AnyContext();
                 if (entry == null)
                 {
                     _logger.LogError("{WorkId} Error getting queue entry for work item timeout", workId);
@@ -711,7 +711,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 if (DisposedCancellationToken.IsCancellationRequested)
                     return;
 
-                var waitTimeTicks = await _cache.GetAsync<long>(GetWaitTimeKey(waitId)).AnyContext();
+                var waitTimeTicks = await _cache.GetAsync<long>(GetWaitTimeKey(waitId!)).AnyContext();
                 _logger.LogTrace("{WaitId}: Wait time {WaitTime}", waitId, waitTimeTicks);
 
                 if (waitTimeTicks.HasValue && waitTimeTicks.Value > utcNow.Ticks)
@@ -723,7 +723,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
                 var tx = Database.CreateTransaction();
                 tx.ListRemoveAsync(_waitListName, waitId);
                 tx.ListLeftPushAsync(_queueListName, waitId);
-                tx.KeyDeleteAsync(GetWaitTimeKey(waitId));
+                tx.KeyDeleteAsync(GetWaitTimeKey(waitId!));
                 bool success = await _resiliencePolicy.ExecuteAsync(async _ => await tx.ExecuteAsync()).AnyContext();
                 if (!success)
                     throw new Exception("Unable to move item to queue list.");
@@ -865,7 +865,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
 
 public class RedisPayloadEnvelope<T>
 {
-    public string CorrelationId { get; set; }
-    public IDictionary<string, string> Properties { get; set; }
-    public T Value { get; set; }
+    public string? CorrelationId { get; set; }
+    public IDictionary<string, string>? Properties { get; set; }
+    public T Value { get; set; } = default!;
 }

--- a/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
@@ -7,7 +7,7 @@ namespace Foundatio.Queues;
 // TODO: Make queue settings immutable and stored in redis so that multiple clients can't have different settings.
 public class RedisQueueOptions<T> : SharedQueueOptions<T> where T : class
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
+    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMinutes(1);
     public int[] RetryMultipliers { get; set; } = { 1, 3, 5, 10 };
     public TimeSpan DeadLetterTimeToLive { get; set; } = TimeSpan.FromDays(1);

--- a/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueueOptions.cs
@@ -7,7 +7,7 @@ namespace Foundatio.Queues;
 // TODO: Make queue settings immutable and stored in redis so that multiple clients can't have different settings.
 public class RedisQueueOptions<T> : SharedQueueOptions<T> where T : class
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
+    public IConnectionMultiplexer? ConnectionMultiplexer { get; set; }
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMinutes(1);
     public int[] RetryMultipliers { get; set; } = { 1, 3, 5, 10 };
     public TimeSpan DeadLetterTimeToLive { get; set; } = TimeSpan.FromDays(1);

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -67,11 +67,8 @@ public class RedisFileStorage : IFileStorage
         return await GetFileContentStreamAsync(NormalizePath(path), _options.ReadMode, cancellationToken).AnyContext();
     }
 
-    private async Task<MemoryStream?> GetFileContentStreamAsync(string? normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
+    private async Task<MemoryStream?> GetFileContentStreamAsync(string normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(normalizedPath))
-            return null;
-
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         var fileContent = await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashGetAsync(_options.ContainerName, normalizedPath, flags), cancellationToken).AnyContext();
@@ -81,7 +78,7 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return new MemoryStream(((byte[]?)fileContent)!);
+        return new MemoryStream((byte[]?)fileContent ?? []);
     }
 
     public async Task<FileSpec?> GetFileInfoAsync(string path)
@@ -89,10 +86,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string? normalizedPath = NormalizePath(path);
-        if (normalizedPath is null)
-            return null;
-
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var fileSpec = await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashGetAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -102,7 +96,7 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return _serializer.Deserialize<FileSpec>(((byte[]?)fileSpec)!);
+        return _serializer.Deserialize<FileSpec>((byte[]?)fileSpec ?? []);
     }
 
     public async Task<bool> ExistsAsync(string path)
@@ -110,10 +104,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string? normalizedPath = NormalizePath(path);
-        if (normalizedPath is null)
-            return false;
-
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         return await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashExistsAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -126,10 +117,7 @@ public class RedisFileStorage : IFileStorage
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
 
-        string? normalizedPath = NormalizePath(path);
-        if (normalizedPath is null)
-            return false;
-
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         try
@@ -170,11 +158,8 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(newPath))
             throw new ArgumentNullException(nameof(newPath));
 
-        string? normalizedPath = NormalizePath(path);
-        string? normalizedNewPath = NormalizePath(newPath);
-        if (normalizedPath is null || normalizedNewPath is null)
-            return false;
-
+        string normalizedPath = NormalizePath(path);
+        string normalizedNewPath = NormalizePath(newPath);
         _logger.LogInformation("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         try
@@ -204,11 +189,8 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(targetPath))
             throw new ArgumentNullException(nameof(targetPath));
 
-        string? normalizedPath = NormalizePath(path);
-        string? normalizedTargetPath = NormalizePath(targetPath);
-        if (normalizedPath is null || normalizedTargetPath is null)
-            return false;
-
+        string normalizedPath = NormalizePath(path);
+        string normalizedTargetPath = NormalizePath(targetPath);
         _logger.LogInformation("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -235,10 +217,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string? normalizedPath = NormalizePath(path);
-        if (normalizedPath is null)
-            return false;
-
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         var database = Database;
@@ -347,15 +326,15 @@ public class RedisFileStorage : IFileStorage
         };
     }
 
-    private string? NormalizePath(string? path)
+    private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
-    private class SearchCriteria
+    private record SearchCriteria
     {
-        public string Prefix { get; set; } = String.Empty;
-        public Regex? Pattern { get; set; }
+        public required string Prefix { get; init; }
+        public Regex? Pattern { get; init; }
     }
 
     private SearchCriteria GetRequestCriteria(string? searchPattern)
@@ -363,9 +342,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string? normalizedSearchPattern = NormalizePath(searchPattern);
-        if (normalizedSearchPattern is null)
-            return new SearchCriteria { Prefix = String.Empty };
+        string normalizedSearchPattern = NormalizePath(searchPattern);
 
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -64,7 +64,7 @@ public class RedisFileStorage : IFileStorage
         if (streamMode is StreamMode.Write)
             throw new NotSupportedException($"Stream mode {streamMode} is not supported.");
 
-        return await GetFileContentStreamAsync(NormalizePath(path), _options.ReadMode, cancellationToken).AnyContext();
+        return await GetFileContentStreamAsync(NormalizePath(path)!, _options.ReadMode, cancellationToken).AnyContext();
     }
 
     private async Task<MemoryStream?> GetFileContentStreamAsync(string normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
@@ -86,7 +86,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var fileSpec = await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashGetAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -104,7 +104,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         return await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashExistsAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -117,7 +117,7 @@ public class RedisFileStorage : IFileStorage
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         try
@@ -158,8 +158,8 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(newPath))
             throw new ArgumentNullException(nameof(newPath));
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedNewPath = NormalizePath(newPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedNewPath = NormalizePath(newPath)!;
         _logger.LogInformation("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         try
@@ -189,8 +189,8 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(targetPath))
             throw new ArgumentNullException(nameof(targetPath));
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedTargetPath = NormalizePath(targetPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedTargetPath = NormalizePath(targetPath)!;
         _logger.LogInformation("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -217,7 +217,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         var database = Database;
@@ -326,12 +326,9 @@ public class RedisFileStorage : IFileStorage
         };
     }
 
-    private string NormalizePath(string? path)
+    private string? NormalizePath(string? path)
     {
-        if (String.IsNullOrEmpty(path))
-            return path ?? String.Empty;
-
-        return path.Replace('\\', '/');
+        return path?.Replace('\\', '/');
     }
 
     private class SearchCriteria
@@ -345,7 +342,7 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern);
+        string normalizedSearchPattern = NormalizePath(searchPattern)!;
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -246,7 +246,8 @@ public class RedisFileStorage : IFileStorage
         if (limit is <= 0)
             return Task.FromResult(new List<FileSpec>());
 
-        searchPattern = searchPattern?.Replace('\\', '/');
+        if (searchPattern is not null)
+            searchPattern = NormalizePath(searchPattern);
         string? prefix = searchPattern;
         Regex? patternRegex = null;
         int wildcardPos = searchPattern?.IndexOf('*') ?? -1;
@@ -261,8 +262,8 @@ public class RedisFileStorage : IFileStorage
         int pageSize = limit ?? Int32.MaxValue;
 
         _logger.LogTrace(
-            s => s.Property("SearchPattern", searchPattern ?? string.Empty).Property("Limit", limit ?? -1).Property("Skip", skip ?? 0),
-            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex as object ?? "(none)"
+            s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
+            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex!
         );
 
         return Task.FromResult(Database.HashScan(_fileSpecContainer, $"{prefix}*", flags: _options.ReadMode)
@@ -294,7 +295,7 @@ public class RedisFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("Limit", pagingLimit).Property("Skip", skip),
-            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern as object ?? "(none)"
+            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern!
         );
 
         var list = Database.HashScan(_fileSpecContainer, $"{criteria.Prefix}*", flags: _options.ReadMode)
@@ -328,7 +329,7 @@ public class RedisFileStorage : IFileStorage
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; } = string.Empty;
+        public string Prefix { get; set; } = String.Empty;
         public Regex? Pattern { get; set; }
     }
 

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -265,7 +265,7 @@ public class RedisFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex!
+            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex
         );
 
         return Task.FromResult(Database.HashScan(_fileSpecContainer, $"{prefix}*", flags: _options.ReadMode)
@@ -298,7 +298,7 @@ public class RedisFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("Limit", pagingLimit).Property("Skip", skip),
-            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern!
+            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
         );
 
         var list = Database.HashScan(_fileSpecContainer, $"{criteria.Prefix}*", flags: _options.ReadMode)

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -51,10 +51,10 @@ public class RedisFileStorage : IFileStorage
     }
 
     [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
-    public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
+    public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-    public async Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
+    public async Task<Stream?> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -65,7 +65,7 @@ public class RedisFileStorage : IFileStorage
         return await GetFileContentStreamAsync(NormalizePath(path), _options.ReadMode, cancellationToken).AnyContext();
     }
 
-    private async Task<MemoryStream> GetFileContentStreamAsync(string normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
+    private async Task<MemoryStream?> GetFileContentStreamAsync(string normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
     {
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
@@ -76,10 +76,10 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return new MemoryStream(fileContent);
+        return new MemoryStream(((byte[]?)fileContent)!);
     }
 
-    public async Task<FileSpec> GetFileInfoAsync(string path)
+    public async Task<FileSpec?> GetFileInfoAsync(string path)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -94,7 +94,7 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return _serializer.Deserialize<FileSpec>((byte[])fileSpec);
+        return _serializer.Deserialize<FileSpec>(((byte[]?)fileSpec)!);
     }
 
     public async Task<bool> ExistsAsync(string path)
@@ -225,7 +225,7 @@ public class RedisFileStorage : IFileStorage
         return true;
     }
 
-    public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<int> DeleteFilesAsync(string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         var files = await GetFileListAsync(searchPattern, cancellationToken: cancellationToken).AnyContext();
         int count = 0;
@@ -241,14 +241,14 @@ public class RedisFileStorage : IFileStorage
         return count;
     }
 
-    private Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
+    private Task<List<FileSpec>> GetFileListAsync(string? searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
     {
         if (limit is <= 0)
             return Task.FromResult(new List<FileSpec>());
 
-        searchPattern = NormalizePath(searchPattern);
-        string prefix = searchPattern;
-        Regex patternRegex = null;
+        searchPattern = searchPattern?.Replace('\\', '/');
+        string? prefix = searchPattern;
+        Regex? patternRegex = null;
         int wildcardPos = searchPattern?.IndexOf('*') ?? -1;
         if (searchPattern != null && wildcardPos >= 0)
         {
@@ -261,19 +261,20 @@ public class RedisFileStorage : IFileStorage
         int pageSize = limit ?? Int32.MaxValue;
 
         _logger.LogTrace(
-            s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex
+            s => s.Property("SearchPattern", searchPattern ?? string.Empty).Property("Limit", limit ?? -1).Property("Skip", skip ?? 0),
+            "Getting file list matching {Prefix} and {Pattern}...", prefix, patternRegex as object ?? "(none)"
         );
 
         return Task.FromResult(Database.HashScan(_fileSpecContainer, $"{prefix}*", flags: _options.ReadMode)
-            .Select(entry => _serializer.Deserialize<FileSpec>((byte[])entry.Value))
-            .Where(fileSpec => patternRegex == null || patternRegex.IsMatch(fileSpec.Path))
+            .Select(entry => _serializer.Deserialize<FileSpec>(((byte[]?)entry.Value)!))
+            .Where(fileSpec => fileSpec is not null && (patternRegex is null || patternRegex.IsMatch(fileSpec.Path)))
+            .Cast<FileSpec>()
             .Take(pageSize)
             .ToList()
         );
     }
 
-    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         if (pageSize <= 0)
             return PagedFileListResult.Empty;
@@ -293,12 +294,13 @@ public class RedisFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("Limit", pagingLimit).Property("Skip", skip),
-            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
+            "Getting files matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern as object ?? "(none)"
         );
 
         var list = Database.HashScan(_fileSpecContainer, $"{criteria.Prefix}*", flags: _options.ReadMode)
-            .Select(entry => _serializer.Deserialize<FileSpec>((byte[])entry.Value))
-            .Where(fileSpec => criteria.Pattern == null || criteria.Pattern.IsMatch(fileSpec.Path))
+            .Select(entry => _serializer.Deserialize<FileSpec>(((byte[]?)entry.Value)!))
+            .Where(fileSpec => fileSpec is not null && (criteria.Pattern is null || criteria.Pattern.IsMatch(fileSpec.Path)))
+            .Cast<FileSpec>()
             .Skip(skip)
             .Take(pagingLimit)
             .ToList();
@@ -321,16 +323,16 @@ public class RedisFileStorage : IFileStorage
 
     private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; }
-        public Regex Pattern { get; set; }
+        public string Prefix { get; set; } = string.Empty;
+        public Regex? Pattern { get; set; }
     }
 
-    private SearchCriteria GetRequestCriteria(string searchPattern)
+    private SearchCriteria GetRequestCriteria(string? searchPattern)
     {
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
@@ -340,7 +342,7 @@ public class RedisFileStorage : IFileStorage
         bool hasWildcard = wildcardPos >= 0;
 
         string prefix = normalizedSearchPattern;
-        Regex patternRegex = null;
+        Regex? patternRegex = null;
 
         if (hasWildcard)
         {
@@ -356,7 +358,7 @@ public class RedisFileStorage : IFileStorage
         };
     }
 
-    private void ConnectionMultiplexerOnConnectionRestored(object sender, ConnectionFailedEventArgs connectionFailedEventArgs)
+    private void ConnectionMultiplexerOnConnectionRestored(object? sender, ConnectionFailedEventArgs connectionFailedEventArgs)
     {
         _logger.LogInformation("Redis connection restored");
     }

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -52,7 +52,7 @@ public class RedisFileStorage : IFileStorage
         _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
     }
 
-    [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
+    [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(StreamMode)} instead to define read or write behaviour of stream")]
     public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
@@ -78,7 +78,7 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return new MemoryStream((byte[]?)fileContent ?? []);
+        return new MemoryStream((byte[])fileContent!);
     }
 
     public async Task<FileSpec?> GetFileInfoAsync(string path)
@@ -96,7 +96,7 @@ public class RedisFileStorage : IFileStorage
             return null;
         }
 
-        return _serializer.Deserialize<FileSpec>((byte[]?)fileSpec ?? []);
+        return _serializer.Deserialize<FileSpec>((byte[])fileSpec!);
     }
 
     public async Task<bool> ExistsAsync(string path)
@@ -270,7 +270,7 @@ public class RedisFileStorage : IFileStorage
 
         return Task.FromResult(Database.HashScan(_fileSpecContainer, $"{prefix}*", flags: _options.ReadMode)
             .Where(entry => entry.Value.HasValue)
-            .Select(entry => _serializer.Deserialize<FileSpec>((byte[]?)entry.Value ?? []))
+            .Select(entry => _serializer.Deserialize<FileSpec>((byte[])entry.Value!))
             .Where(fileSpec => fileSpec is not null && (patternRegex is null || patternRegex.IsMatch(fileSpec.Path)))
             .Cast<FileSpec>()
             .Take(pageSize)
@@ -303,7 +303,7 @@ public class RedisFileStorage : IFileStorage
 
         var list = Database.HashScan(_fileSpecContainer, $"{criteria.Prefix}*", flags: _options.ReadMode)
             .Where(entry => entry.Value.HasValue)
-            .Select(entry => _serializer.Deserialize<FileSpec>((byte[]?)entry.Value ?? []))
+            .Select(entry => _serializer.Deserialize<FileSpec>((byte[])entry.Value!))
             .Where(fileSpec => fileSpec is not null && (criteria.Pattern is null || criteria.Pattern.IsMatch(fileSpec.Path)))
             .Cast<FileSpec>()
             .Skip(skip)

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -64,11 +64,14 @@ public class RedisFileStorage : IFileStorage
         if (streamMode is StreamMode.Write)
             throw new NotSupportedException($"Stream mode {streamMode} is not supported.");
 
-        return await GetFileContentStreamAsync(NormalizePath(path)!, _options.ReadMode, cancellationToken).AnyContext();
+        return await GetFileContentStreamAsync(NormalizePath(path), _options.ReadMode, cancellationToken).AnyContext();
     }
 
-    private async Task<MemoryStream?> GetFileContentStreamAsync(string normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
+    private async Task<MemoryStream?> GetFileContentStreamAsync(string? normalizedPath, CommandFlags flags, CancellationToken cancellationToken = default)
     {
+        if (String.IsNullOrEmpty(normalizedPath))
+            return null;
+
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         var fileContent = await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashGetAsync(_options.ContainerName, normalizedPath, flags), cancellationToken).AnyContext();
@@ -86,7 +89,10 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path)!;
+        string? normalizedPath = NormalizePath(path);
+        if (normalizedPath is null)
+            return null;
+
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var fileSpec = await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashGetAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -104,7 +110,10 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path)!;
+        string? normalizedPath = NormalizePath(path);
+        if (normalizedPath is null)
+            return false;
+
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         return await _resiliencePolicy.ExecuteAsync(async _ => await Database.HashExistsAsync(_fileSpecContainer, normalizedPath, _options.ReadMode)).AnyContext();
@@ -117,7 +126,10 @@ public class RedisFileStorage : IFileStorage
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
 
-        string normalizedPath = NormalizePath(path)!;
+        string? normalizedPath = NormalizePath(path);
+        if (normalizedPath is null)
+            return false;
+
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         try
@@ -158,8 +170,11 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(newPath))
             throw new ArgumentNullException(nameof(newPath));
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedNewPath = NormalizePath(newPath)!;
+        string? normalizedPath = NormalizePath(path);
+        string? normalizedNewPath = NormalizePath(newPath);
+        if (normalizedPath is null || normalizedNewPath is null)
+            return false;
+
         _logger.LogInformation("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         try
@@ -189,8 +204,11 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(targetPath))
             throw new ArgumentNullException(nameof(targetPath));
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedTargetPath = NormalizePath(targetPath)!;
+        string? normalizedPath = NormalizePath(path);
+        string? normalizedTargetPath = NormalizePath(targetPath);
+        if (normalizedPath is null || normalizedTargetPath is null)
+            return false;
+
         _logger.LogInformation("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -217,7 +235,10 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
 
-        string normalizedPath = NormalizePath(path)!;
+        string? normalizedPath = NormalizePath(path);
+        if (normalizedPath is null)
+            return false;
+
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         var database = Database;
@@ -342,7 +363,10 @@ public class RedisFileStorage : IFileStorage
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern)!;
+        string? normalizedSearchPattern = NormalizePath(searchPattern);
+        if (normalizedSearchPattern is null)
+            return new SearchCriteria { Prefix = String.Empty };
+
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -17,6 +17,7 @@ namespace Foundatio.Storage;
 public class RedisFileStorage : IFileStorage
 {
     private readonly RedisFileStorageOptions _options;
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly ISerializer _serializer;
     private readonly IResiliencePolicy _resiliencePolicy;
     private readonly ILogger _logger;
@@ -24,16 +25,18 @@ public class RedisFileStorage : IFileStorage
 
     public RedisFileStorage(RedisFileStorageOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
 
+        _options = options;
+        _connectionMultiplexer = options.ConnectionMultiplexer;
         _serializer = options.Serializer ?? DefaultSerializer.Instance;
         _logger = options.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
 
         _resiliencePolicy = options.ResiliencePolicyProvider.GetPolicy<RedisFileStorage, IFileStorage>(_logger, options.TimeProvider);
 
-        options.ConnectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
         _fileSpecContainer = $"{options.ContainerName}-filespecs";
-        _options = options;
     }
 
     public RedisFileStorage(Builder<RedisFileStorageOptionsBuilder, RedisFileStorageOptions> config)
@@ -42,11 +45,11 @@ public class RedisFileStorage : IFileStorage
     }
 
     ISerializer IHaveSerializer.Serializer => _serializer;
-    public IDatabase Database => _options.ConnectionMultiplexer.GetDatabase();
+    public IDatabase Database => _connectionMultiplexer.GetDatabase();
 
     public void Dispose()
     {
-        _options.ConnectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
+        _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
     }
 
     [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
@@ -266,7 +269,8 @@ public class RedisFileStorage : IFileStorage
         );
 
         return Task.FromResult(Database.HashScan(_fileSpecContainer, $"{prefix}*", flags: _options.ReadMode)
-            .Select(entry => _serializer.Deserialize<FileSpec>(((byte[]?)entry.Value)!))
+            .Where(entry => entry.Value.HasValue)
+            .Select(entry => _serializer.Deserialize<FileSpec>((byte[]?)entry.Value ?? []))
             .Where(fileSpec => fileSpec is not null && (patternRegex is null || patternRegex.IsMatch(fileSpec.Path)))
             .Cast<FileSpec>()
             .Take(pageSize)
@@ -298,7 +302,8 @@ public class RedisFileStorage : IFileStorage
         );
 
         var list = Database.HashScan(_fileSpecContainer, $"{criteria.Prefix}*", flags: _options.ReadMode)
-            .Select(entry => _serializer.Deserialize<FileSpec>(((byte[]?)entry.Value)!))
+            .Where(entry => entry.Value.HasValue)
+            .Select(entry => _serializer.Deserialize<FileSpec>((byte[]?)entry.Value ?? []))
             .Where(fileSpec => fileSpec is not null && (criteria.Pattern is null || criteria.Pattern.IsMatch(fileSpec.Path)))
             .Cast<FileSpec>()
             .Skip(skip)
@@ -321,8 +326,11 @@ public class RedisFileStorage : IFileStorage
         };
     }
 
-    private string NormalizePath(string path)
+    private string NormalizePath(string? path)
     {
+        if (String.IsNullOrEmpty(path))
+            return path ?? String.Empty;
+
         return path.Replace('\\', '/');
     }
 

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -24,8 +24,7 @@ public class RedisFileStorage : IFileStorage
 
     public RedisFileStorage(RedisFileStorageOptions options)
     {
-        if (options.ConnectionMultiplexer == null)
-            throw new ArgumentException("ConnectionMultiplexer is required.");
+        ArgumentNullException.ThrowIfNull(options.ConnectionMultiplexer);
 
         _serializer = options.Serializer ?? DefaultSerializer.Instance;
         _logger = options.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;

--- a/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Storage;
 
 public class RedisFileStorageOptions : SharedOptions
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
+    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
     public string ContainerName { get; set; } = "storage";
 
     /// <summary>

--- a/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Storage;
 
 public class RedisFileStorageOptions : SharedOptions
 {
-    public IConnectionMultiplexer? ConnectionMultiplexer { get; set; }
+    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
     public string ContainerName { get; set; } = "storage";
 
     /// <summary>

--- a/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorageOptions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Storage;
 
 public class RedisFileStorageOptions : SharedOptions
 {
-    public IConnectionMultiplexer ConnectionMultiplexer { get; set; } = null!;
+    public IConnectionMultiplexer? ConnectionMultiplexer { get; set; }
     public string ContainerName { get; set; } = "storage";
 
     /// <summary>

--- a/src/Foundatio.Redis/Utility/EmbeddedResourceLoader.cs
+++ b/src/Foundatio.Redis/Utility/EmbeddedResourceLoader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -9,7 +10,8 @@ internal static class EmbeddedResourceLoader
     {
         var assembly = typeof(EmbeddedResourceLoader).GetTypeInfo().Assembly;
 
-        using var stream = assembly.GetManifestResourceStream(name);
+        using var stream = assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException($"Embedded resource '{name}' not found in assembly '{assembly.FullName}'");
         using var streamReader = new StreamReader(stream);
         return streamReader.ReadToEnd();
     }

--- a/src/Foundatio.Redis/Utility/RedisPattern.cs
+++ b/src/Foundatio.Redis/Utility/RedisPattern.cs
@@ -11,7 +11,7 @@ public static class RedisPattern
     /// See https://redis.io/docs/latest/commands/keys/ and
     /// https://redis.io/docs/latest/commands/scan/ for details.
     /// </summary>
-    public static string Escape(string value)
+    public static string? Escape(string? value)
     {
         if (String.IsNullOrEmpty(value))
             return value;

--- a/tests/Foundatio.Benchmarks/Queues/JobQueueBenchmarks.cs
+++ b/tests/Foundatio.Benchmarks/Queues/JobQueueBenchmarks.cs
@@ -67,11 +67,11 @@ public class JobQueueBenchmarks
 
 public class BenchmarkJobQueue : QueueJobBase<QueueItem>
 {
-    public BenchmarkJobQueue(Lazy<IQueue<QueueItem>> queue, ILoggerFactory loggerFactory = null) : base(queue, null, null, loggerFactory)
+    public BenchmarkJobQueue(Lazy<IQueue<QueueItem>> queue, ILoggerFactory? loggerFactory = null) : base(queue, null, null, loggerFactory)
     {
     }
 
-    public BenchmarkJobQueue(IQueue<QueueItem> queue, ILoggerFactory loggerFactory = null) : base(queue, null, null, loggerFactory)
+    public BenchmarkJobQueue(IQueue<QueueItem> queue, ILoggerFactory? loggerFactory = null) : base(queue, null, null, loggerFactory)
     {
     }
 

--- a/tests/Foundatio.Benchmarks/Queues/QueueBenchmarks.cs
+++ b/tests/Foundatio.Benchmarks/Queues/QueueBenchmarks.cs
@@ -63,8 +63,9 @@ public class QueueBenchmarks
         {
             for (int i = 0; i < ITEM_COUNT; i++)
             {
-                var entry = queue.DequeueAsync(TimeSpan.Zero).GetAwaiter().GetResult();
-                entry?.CompleteAsync().GetAwaiter().GetResult();
+                var entry = queue.DequeueAsync(TimeSpan.Zero).GetAwaiter().GetResult()
+                    ?? throw new InvalidOperationException($"Expected a queue entry at index {i}, but dequeue returned null.");
+                entry.CompleteAsync().GetAwaiter().GetResult();
             }
         }
         catch (Exception ex)

--- a/tests/Foundatio.Benchmarks/Queues/QueueBenchmarks.cs
+++ b/tests/Foundatio.Benchmarks/Queues/QueueBenchmarks.cs
@@ -64,7 +64,7 @@ public class QueueBenchmarks
             for (int i = 0; i < ITEM_COUNT; i++)
             {
                 var entry = queue.DequeueAsync(TimeSpan.Zero).GetAwaiter().GetResult();
-                entry.CompleteAsync().GetAwaiter().GetResult();
+                entry?.CompleteAsync().GetAwaiter().GetResult();
             }
         }
         catch (Exception ex)

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -636,7 +636,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetMuxer(Log, Protocol).GetDatabase();
+        var db = SharedConnection.GetRequiredMuxer(Log, Protocol).GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;
@@ -669,7 +669,9 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
             await cache.RemoveAllAsync();
 
             await db.SetAddAsync(key, items.ToArray());
-            await cache.ListRemoveAsync(key, items[10].ToString());
+            string? itemToRemove = (string?)items[10];
+            Assert.NotNull(itemToRemove);
+            await cache.ListRemoveAsync(key, itemToRemove);
 
             listItems = await cache.GetListAsync<string>(key);
             Assert.Equal(items.Count - 1, listItems.Value.Count);
@@ -679,7 +681,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,10 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -636,7 +639,10 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetRequiredMuxer(Log, Protocol).GetDatabase();
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
+        var db = muxer.GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;
@@ -681,7 +687,9 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -636,7 +636,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetMuxer(Log, Protocol)!.GetDatabase();
+        var db = SharedConnection.GetMuxer(Log, Protocol).GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -679,7 +679,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -699,6 +699,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask DisposeAsync()
     {
         _logger.LogDebug("Disposing");
+
         return ValueTask.CompletedTask;
     }
 }

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -334,7 +334,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [InlineData("s", 1)] // Partial prefix match
     [InlineData(null, 1)] // Null prefix (all keys in scope)
     [InlineData("", 1)] // Empty prefix (all keys in scope)
-    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string prefixToRemove, int expectedRemovedCount)
+    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string? prefixToRemove, int expectedRemovedCount)
     {
         return base.RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(prefixToRemove, expectedRemovedCount);
     }
@@ -342,7 +342,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string prefix)
+    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string? prefix)
     {
         return base.RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(prefix);
     }
@@ -636,7 +636,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetMuxer(Log, Protocol).GetDatabase();
+        var db = SharedConnection.GetMuxer(Log, Protocol)!.GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;
@@ -669,7 +669,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
             await cache.RemoveAllAsync();
 
             await db.SetAddAsync(key, items.ToArray());
-            await cache.ListRemoveAsync(key, (string)items[10]);
+            await cache.ListRemoveAsync(key, ((string?)items[10])!);
 
             listItems = await cache.GetListAsync<string>(key);
             Assert.Equal(items.Count - 1, listItems.Value.Count);
@@ -679,7 +679,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -636,7 +636,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetMuxer(Log, Protocol).GetDatabase();
+        var db = SharedConnection.GetMuxer(Log, Protocol)!.GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;
@@ -669,7 +669,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
             await cache.RemoveAllAsync();
 
             await db.SetAddAsync(key, items.ToArray());
-            await cache.ListRemoveAsync(key, ((string?)items[10])!);
+            await cache.ListRemoveAsync(key, items[10].ToString());
 
             listItems = await cache.GetListAsync<string>(key);
             Assert.Equal(items.Count - 1, listItems.Value.Count);
@@ -679,7 +679,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -20,7 +20,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
+        return new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
     [Fact]
@@ -636,7 +636,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Fact]
     public async Task GetListAsync_WithExistingFormat_UpgradeListType()
     {
-        var db = SharedConnection.GetMuxer(Log, Protocol)!.GetDatabase();
+        var db = SharedConnection.GetMuxer(Log, Protocol).GetDatabase();
         var cache = GetCacheClient();
         if (cache == null)
             return;
@@ -679,7 +679,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisCacheClientTests.cs
@@ -18,11 +18,12 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     {
     }
 
-    protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
+    protected override ICacheClient? GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError));
     }
 
@@ -642,9 +643,10 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         var db = muxer.GetDatabase();
         var cache = GetCacheClient();
-        if (cache == null)
+        if (cache is null)
             return;
 
         using (cache)
@@ -690,6 +692,7 @@ public class RedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -19,7 +19,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -380,7 +380,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     [InlineData("s", 1)] // Partial prefix match
     [InlineData(null, 1)] // Null prefix (all keys in scope)
     [InlineData("", 1)] // Empty prefix (all keys in scope)
-    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string prefixToRemove, int expectedRemovedCount)
+    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string? prefixToRemove, int expectedRemovedCount)
     {
         return base.RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(prefixToRemove, expectedRemovedCount);
     }
@@ -388,7 +388,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string prefix)
+    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string? prefix)
     {
         return base.RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(prefix);
     }
@@ -724,7 +724,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -19,7 +19,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -724,7 +724,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -18,8 +18,11 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+                .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -724,7 +727,9 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -19,7 +19,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -724,7 +724,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -19,7 +19,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -724,7 +724,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/RedisHybridCacheClientTests.cs
@@ -16,11 +16,12 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
     {
     }
 
-    protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
+    protected override ICacheClient? GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new RedisHybridCacheClient(o => o
                 .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
@@ -730,6 +731,7 @@ public class RedisHybridCacheClientTests : HybridCacheClientTestBase, IAsyncLife
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -18,7 +18,10 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
+        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
     [Fact]
@@ -585,7 +588,9 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -16,11 +16,12 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     {
     }
 
-    protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
+    protected override ICacheClient? GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
@@ -591,6 +592,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -18,7 +18,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
+        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
     [Fact]
@@ -585,7 +585,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -18,7 +18,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
+        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
     [Fact]
@@ -585,7 +585,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -18,7 +18,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
+        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
     [Fact]
@@ -283,7 +283,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [InlineData("s", 1)] // Partial prefix match
     [InlineData(null, 1)] // Null prefix (all keys in scope)
     [InlineData("", 1)] // Empty prefix (all keys in scope)
-    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string prefixToRemove, int expectedRemovedCount)
+    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string? prefixToRemove, int expectedRemovedCount)
     {
         return base.RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(prefixToRemove, expectedRemovedCount);
     }
@@ -291,7 +291,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string prefix)
+    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string? prefix)
     {
         return base.RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(prefix);
     }
@@ -585,7 +585,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -599,6 +599,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask DisposeAsync()
     {
         _logger.LogDebug("Disposing");
+
         return ValueTask.CompletedTask;
     }
 }

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisCacheClientTests.cs
@@ -18,7 +18,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
+        return new ScopedCacheClient(new RedisCacheClient(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError)), "scoped");
     }
 
     [Fact]
@@ -585,7 +585,7 @@ public class ScopedRedisCacheClientTests : CacheClientTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -16,8 +16,11 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+                .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -26,8 +29,11 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
 
     protected override HybridCacheClient GetDistributedHybridCacheClient(bool shouldThrowOnSerializationError = true)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+                .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -700,7 +706,9 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -17,7 +17,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -27,7 +27,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override HybridCacheClient GetDistributedHybridCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -700,7 +700,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -17,7 +17,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -27,7 +27,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override HybridCacheClient GetDistributedHybridCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -700,7 +700,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -14,11 +14,12 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
 
     public ScopedRedisHybridCacheClientTests(ITestOutputHelper output) : base(output) { }
 
-    protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
+    protected override ICacheClient? GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
                 .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
@@ -32,6 +33,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return null!;
+
         return new RedisHybridCacheClient(o => o
                 .ConnectionMultiplexer(muxer)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
@@ -709,6 +711,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -17,7 +17,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -27,7 +27,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override HybridCacheClient GetDistributedHybridCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -700,7 +700,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
+++ b/tests/Foundatio.Redis.Tests/Caching/ScopedRedisHybridCacheClientTests.cs
@@ -17,7 +17,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new ScopedCacheClient(new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -27,7 +27,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     protected override HybridCacheClient GetDistributedHybridCacheClient(bool shouldThrowOnSerializationError = true)
     {
         return new RedisHybridCacheClient(o => o
-                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+                .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .LoggerFactory(Log).ShouldThrowOnSerializationError(shouldThrowOnSerializationError),
             localConfig => localConfig
                 .CloneValues(true)
@@ -356,7 +356,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     [InlineData("s", 1)] // Partial prefix match
     [InlineData(null, 1)] // Null prefix (all keys in scope)
     [InlineData("", 1)] // Empty prefix (all keys in scope)
-    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string prefixToRemove, int expectedRemovedCount)
+    public override Task RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(string? prefixToRemove, int expectedRemovedCount)
     {
         return base.RemoveByPrefixAsync_FromScopedCache_RemovesOnlyScopedKeys(prefixToRemove, expectedRemovedCount);
     }
@@ -364,7 +364,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string prefix)
+    public override Task RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(string? prefix)
     {
         return base.RemoveByPrefixAsync_NullOrEmptyPrefixWithScopedCache_RemovesCorrectKeys(prefix);
     }
@@ -700,7 +700,7 @@ public class ScopedRedisHybridCacheClientTests : HybridCacheClientTestBase, IAsy
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.48" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.42" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.48" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.42" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
@@ -19,8 +19,11 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
 
     protected override IQueue<SampleQueueWorkItem> GetSampleWorkItemQueue(int retries, TimeSpan retryDelay)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         return new RedisQueue<SampleQueueWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+            .ConnectionMultiplexer(muxer)
             .Retries(retries)
             .RetryDelay(retryDelay)
             .LoggerFactory(Log)
@@ -54,7 +57,9 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
@@ -22,6 +22,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return null!;
+
         return new RedisQueue<SampleQueueWorkItem>(o => o
             .ConnectionMultiplexer(muxer)
             .Retries(retries)
@@ -60,6 +61,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
@@ -20,7 +20,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     protected override IQueue<SampleQueueWorkItem> GetSampleWorkItemQueue(int retries, TimeSpan retryDelay)
     {
         return new RedisQueue<SampleQueueWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
             .Retries(retries)
             .RetryDelay(retryDelay)
             .LoggerFactory(Log)
@@ -54,7 +54,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
@@ -20,7 +20,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     protected override IQueue<SampleQueueWorkItem> GetSampleWorkItemQueue(int retries, TimeSpan retryDelay)
     {
         return new RedisQueue<SampleQueueWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
             .Retries(retries)
             .RetryDelay(retryDelay)
             .LoggerFactory(Log)
@@ -54,7 +54,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Jobs/RedisJobQueueTests.cs
@@ -20,7 +20,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     protected override IQueue<SampleQueueWorkItem> GetSampleWorkItemQueue(int retries, TimeSpan retryDelay)
     {
         return new RedisQueue<SampleQueueWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
             .Retries(retries)
             .RetryDelay(retryDelay)
             .LoggerFactory(Log)
@@ -54,7 +54,7 @@ public class RedisJobQueueTests : JobQueueTestsBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -37,13 +37,21 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
         _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
 
-    protected override ILockProvider GetThrottlingLockProvider(int maxHits, TimeSpan period)
+    protected override ILockProvider? GetThrottlingLockProvider(int maxHits, TimeSpan period)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null;
+
         return new ThrottlingLockProvider(_cache, maxHits, period, null, null, Log);
     }
 
-    protected override ILockProvider GetLockProvider()
+    protected override ILockProvider? GetLockProvider()
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null;
+
         return new CacheLockProvider(_cache, _messageBus, null, null, Log);
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -25,7 +25,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     protected RedisLockTests(ITestOutputHelper output, RedisProtocol? protocol) : base(output)
     {
         _protocol = protocol;
-        var muxer = SharedConnection.GetMuxer(Log, _protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, _protocol);
         _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
         _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
@@ -115,7 +115,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -26,8 +26,15 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     {
         _protocol = protocol;
         var muxer = SharedConnection.GetMuxer(Log, _protocol);
-        _cache = muxer is null ? null! : new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
-        _messageBus = muxer is null ? null! : new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
+        if (muxer is null)
+        {
+            _cache = null!;
+            _messageBus = null!;
+            return;
+        }
+
+        _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
+        _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
 
     protected override ILockProvider GetThrottlingLockProvider(int maxHits, TimeSpan period)
@@ -118,6 +125,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -25,7 +25,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     protected RedisLockTests(ITestOutputHelper output, RedisProtocol? protocol) : base(output)
     {
         _protocol = protocol;
-        var muxer = SharedConnection.GetMuxer(Log, _protocol);
+        var muxer = SharedConnection.GetMuxer(Log, _protocol)!;
         _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
         _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
@@ -115,7 +115,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -25,13 +25,8 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     protected RedisLockTests(ITestOutputHelper output, RedisProtocol? protocol) : base(output)
     {
         _protocol = protocol;
-        var muxer = SharedConnection.GetMuxer(Log, _protocol);
-        if (muxer is null)
-        {
-            _cache = null!;
-            _messageBus = null!;
-            return;
-        }
+        var muxer = SharedConnection.GetMuxer(Log, _protocol)
+            ?? throw new InvalidOperationException("Redis connection is not configured. Set the RedisConnectionString environment variable.");
 
         _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
         _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -25,7 +25,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     protected RedisLockTests(ITestOutputHelper output, RedisProtocol? protocol) : base(output)
     {
         _protocol = protocol;
-        var muxer = SharedConnection.GetMuxer(Log, _protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, _protocol);
         _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
         _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
@@ -115,7 +115,7 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
+++ b/tests/Foundatio.Redis.Tests/Locks/RedisLockTests.cs
@@ -25,9 +25,9 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     protected RedisLockTests(ITestOutputHelper output, RedisProtocol? protocol) : base(output)
     {
         _protocol = protocol;
-        var muxer = SharedConnection.GetRequiredMuxer(Log, _protocol);
-        _cache = new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
-        _messageBus = new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
+        var muxer = SharedConnection.GetMuxer(Log, _protocol);
+        _cache = muxer is null ? null! : new RedisCacheClient(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
+        _messageBus = muxer is null ? null! : new RedisMessageBus(o => o.Subscriber(muxer.GetSubscriber()).Topic(_topic).LoggerFactory(Log));
     }
 
     protected override ILockProvider GetThrottlingLockProvider(int maxHits, TimeSpan period)
@@ -115,7 +115,9 @@ public class RedisLockTests : LockTestBase, IDisposable, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -29,7 +29,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     {
         return new RedisMessageBus(o =>
         {
-            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol).GetSubscriber());
+            o.Subscriber(SharedConnection.GetRequiredMuxer(Log, Protocol).GetSubscriber());
             o.Topic(_topic);
             o.LoggerFactory(Log);
             if (config != null)
@@ -192,7 +192,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     [Fact]
     public async Task CanDisposeCacheAndQueueAndReceiveSubscribedMessages()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -239,7 +239,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -27,9 +27,12 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
 
     protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         return new RedisMessageBus(o =>
         {
-            o.Subscriber(SharedConnection.GetRequiredMuxer(Log, Protocol).GetSubscriber());
+            o.Subscriber(muxer.GetSubscriber());
             o.Topic(_topic);
             o.LoggerFactory(Log);
             if (config != null)
@@ -192,7 +195,9 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     [Fact]
     public async Task CanDisposeCacheAndQueueAndReceiveSubscribedMessages()
     {
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -239,7 +244,9 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -25,11 +25,11 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     {
     }
 
-    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions> config = null)
+    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
         return new RedisMessageBus(o =>
         {
-            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol).GetSubscriber());
+            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol)!.GetSubscriber());
             o.Topic(_topic);
             o.LoggerFactory(Log);
             if (config != null)
@@ -192,7 +192,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     [Fact]
     public async Task CanDisposeCacheAndQueueAndReceiveSubscribedMessages()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -239,7 +239,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -25,11 +25,12 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     {
     }
 
-    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
+    protected override IMessageBus? GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new RedisMessageBus(o =>
         {
             o.Subscriber(muxer.GetSubscriber());
@@ -198,6 +199,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -247,12 +249,14 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 
     public ValueTask DisposeAsync()
     {
         _logger.LogDebug("Disposing");
+
         return ValueTask.CompletedTask;
     }
 }

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -29,7 +29,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     {
         return new RedisMessageBus(o =>
         {
-            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol).GetSubscriber());
+            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol)!.GetSubscriber());
             o.Topic(_topic);
             o.LoggerFactory(Log);
             if (config != null)
@@ -192,7 +192,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     [Fact]
     public async Task CanDisposeCacheAndQueueAndReceiveSubscribedMessages()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -239,7 +239,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -29,7 +29,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     {
         return new RedisMessageBus(o =>
         {
-            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol)!.GetSubscriber());
+            o.Subscriber(SharedConnection.GetMuxer(Log, Protocol).GetSubscriber());
             o.Topic(_topic);
             o.LoggerFactory(Log);
             if (config != null)
@@ -192,7 +192,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     [Fact]
     public async Task CanDisposeCacheAndQueueAndReceiveSubscribedMessages()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var messageBus1 = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
 
         var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer });
@@ -239,7 +239,7 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -38,7 +38,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     {
         var queue = new RedisQueue<SimpleWorkItem>(o =>
         {
-            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
                 .Retries(retries)
                 .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
                 .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
@@ -212,7 +212,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -222,7 +222,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -262,7 +262,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetMuxer(Log, Protocol);
+            var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -318,7 +318,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -333,6 +333,17 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var workItem = await queue.DequeueAsync();
         Assert.NotNull(workItem);
         await workItem.AbandonAsync();
+        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
+        Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:in"));
+        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:work"));
+        Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:dequeued"));
+        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
+        Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:renewed"));
+        Assert.Equal(1, await db.StringGetAsync($"{listPrefix}:{id}:attempts"));
+        Assert.Equal(4, await muxer.CountAllKeysAsync());
+
+        workItem = await queue.DequeueAsync();
+        Assert.NotNull(workItem);
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
         Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
         Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:work"));
@@ -379,7 +390,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -392,6 +403,10 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var workItem = await queue.DequeueAsync();
         Assert.NotNull(workItem);
         await workItem.AbandonAsync();
+        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
+        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
+        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:work"));
+        Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:wait"));
         Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:dequeued"));
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
         Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:renewed"));
@@ -440,7 +455,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -649,7 +664,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -693,7 +708,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -739,7 +754,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -800,7 +815,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
             name = "cmd";
 
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -821,7 +836,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -825,7 +825,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
 
     private IQueue<T> CreateQueue<T>(bool allQueuesTheSameName = true) where T : class
     {
-        string name = typeof(T).Name.Trim().ToLower();
+        string name = (typeof(T).FullName ?? typeof(T).Name).Trim().Replace(".", String.Empty).ToLower();
 
         if (allQueuesTheSameName)
             name = "cmd";

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -36,24 +36,19 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
     protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
-        var queue = new RedisQueue<SimpleWorkItem>(o =>
-        {
-            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
-                .Retries(retries)
-                .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
-                .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
-                .DeadLetterMaxItems(deadLetterMaxItems)
-                .TimeProvider(timeProvider ?? TimeProvider.System)
-                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-                .MetricsPollingInterval(TimeSpan.Zero)
-                .RunMaintenanceTasks(runQueueMaintenance)
-                .LoggerFactory(Log);
-
-            if (serializer is not null)
-                o.Serializer(serializer);
-
-            return o;
-        });
+        var queue = new RedisQueue<SimpleWorkItem>(o => o
+            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+            .Retries(retries)
+            .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
+            .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
+            .DeadLetterMaxItems(deadLetterMaxItems)
+            .TimeProvider(timeProvider ?? TimeProvider.System)
+            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+            .MetricsPollingInterval(TimeSpan.Zero)
+            .RunMaintenanceTasks(runQueueMaintenance)
+            .Serializer(serializer)
+            .LoggerFactory(Log)
+        );
 
         _logger.LogDebug("Queue Id: {QueueId}", queue.QueueId);
         return queue;
@@ -212,7 +207,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -222,7 +217,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -262,7 +257,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetMuxer(Log, Protocol);
+            var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -318,7 +313,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -390,7 +385,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -455,7 +450,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -664,7 +659,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -708,7 +703,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -754,7 +749,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -809,13 +804,13 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
 
     private IQueue<T> CreateQueue<T>(bool allQueuesTheSameName = true) where T : class
     {
-        string name = (typeof(T).FullName ?? typeof(T).Name).Trim().Replace(".", String.Empty).ToLower();
+        string name = typeof(T).Name.Trim().ToLower();
 
         if (allQueuesTheSameName)
             name = "cmd";
 
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -836,7 +831,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -36,8 +36,11 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
     protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         var queue = new RedisQueue<SimpleWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+            .ConnectionMultiplexer(muxer)
             .Retries(retries)
             .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
             .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
@@ -207,7 +210,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -217,7 +222,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -257,7 +264,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+            var muxer = SharedConnection.GetMuxer(Log, Protocol);
+            if (muxer is null)
+                return;
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -313,7 +322,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -385,7 +396,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -450,7 +463,9 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -659,7 +674,9 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -703,7 +720,9 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -749,7 +768,9 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -809,8 +830,11 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         if (allQueuesTheSameName)
             name = "cmd";
 
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol))
+            .ConnectionMultiplexer(muxer)
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -831,7 +855,9 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return ValueTask.CompletedTask;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -809,7 +809,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
 
     private IQueue<T> CreateQueue<T>(bool allQueuesTheSameName = true) where T : class
     {
-        string name = typeof(T).FullName!.Trim().Replace(".", String.Empty).ToLower();
+        string name = (typeof(T).FullName ?? typeof(T).Name).Trim().Replace(".", String.Empty).ToLower();
 
         if (allQueuesTheSameName)
             name = "cmd";

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -38,7 +38,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     {
         var queue = new RedisQueue<SimpleWorkItem>(o =>
         {
-            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
                 .Retries(retries)
                 .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
                 .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
@@ -212,7 +212,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -222,7 +222,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -262,7 +262,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+            var muxer = SharedConnection.GetMuxer(Log, Protocol);
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -318,7 +318,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -379,7 +379,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -440,7 +440,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -649,7 +649,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -693,7 +693,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -739,7 +739,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -800,7 +800,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
             name = "cmd";
 
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -821,7 +821,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -34,11 +34,12 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
+    protected override IQueue<SimpleWorkItem>? GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         var queue = new RedisQueue<SimpleWorkItem>(o => o
             .ConnectionMultiplexer(muxer)
             .Retries(retries)
@@ -213,6 +214,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -225,6 +227,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -265,14 +268,15 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         using (queue)
         {
             var muxer = SharedConnection.GetMuxer(Log, Protocol);
-            if (muxer is null)
-                return;
-            var db = muxer.GetDatabase();
-            string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
+        if (muxer is null)
+            return;
 
-            string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
-            Assert.NotNull(id);
-            Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
+        var db = muxer.GetDatabase();
+        string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
+
+        string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
+        Assert.NotNull(id);
+        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
             Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:in"));
             Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
             Assert.Equal(3, await muxer.CountAllKeysAsync());
@@ -325,6 +329,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -399,6 +404,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -466,6 +472,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -677,6 +684,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -723,6 +731,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -771,6 +780,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -833,6 +843,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return null!;
+
         var queue = new RedisQueue<T>(o => o
             .ConnectionMultiplexer(muxer)
             .Name(name)
@@ -858,6 +869,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return ValueTask.CompletedTask;
+
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -268,15 +268,15 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         using (queue)
         {
             var muxer = SharedConnection.GetMuxer(Log, Protocol);
-        if (muxer is null)
-            return;
+            if (muxer is null)
+                return;
 
-        var db = muxer.GetDatabase();
-        string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
+            var db = muxer.GetDatabase();
+            string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
-        string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
-        Assert.NotNull(id);
-        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
+            string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
+            Assert.NotNull(id);
+            Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
             Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:in"));
             Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
             Assert.Equal(3, await muxer.CountAllKeysAsync());

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -34,21 +34,26 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[] retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider timeProvider = null, ISerializer serializer = null)
+    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
-        var queue = new RedisQueue<SimpleWorkItem>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
-            .Retries(retries)
-            .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
-            .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
-            .DeadLetterMaxItems(deadLetterMaxItems)
-            .TimeProvider(timeProvider ?? TimeProvider.System)
-            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-            .MetricsPollingInterval(TimeSpan.Zero)
-            .RunMaintenanceTasks(runQueueMaintenance)
-            .Serializer(serializer)
-            .LoggerFactory(Log)
-        );
+        var queue = new RedisQueue<SimpleWorkItem>(o =>
+        {
+            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+                .Retries(retries)
+                .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
+                .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
+                .DeadLetterMaxItems(deadLetterMaxItems)
+                .TimeProvider(timeProvider ?? TimeProvider.System)
+                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+                .MetricsPollingInterval(TimeSpan.Zero)
+                .RunMaintenanceTasks(runQueueMaintenance)
+                .LoggerFactory(Log);
+
+            if (serializer is not null)
+                o.Serializer(serializer);
+
+            return o;
+        });
 
         _logger.LogDebug("Queue Id: {QueueId}", queue.QueueId);
         return queue;
@@ -207,7 +212,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -217,7 +222,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -257,11 +262,12 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetMuxer(Log, Protocol);
+            var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
-            string id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
+            string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = 1 });
+            Assert.NotNull(id);
             Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
             Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:in"));
             Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
@@ -271,6 +277,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
             Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:renewed"));
             var workItem = await queue.DequeueAsync();
+            Assert.NotNull(workItem);
             Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
             Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
             Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:work"));
@@ -311,30 +318,21 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
-        string id = await queue.EnqueueAsync(new SimpleWorkItem
+        string? id = await queue.EnqueueAsync(new SimpleWorkItem
         {
             Data = "blah",
             Id = 1
         });
+        Assert.NotNull(id);
         _logger.LogTrace("SimpleWorkItem Id: {Id}", id);
 
         var workItem = await queue.DequeueAsync();
-        await workItem.AbandonAsync();
-        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
-        Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:in"));
-        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:work"));
-        Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:dequeued"));
-        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
-        Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:renewed"));
-        Assert.Equal(1, await db.StringGetAsync($"{listPrefix}:{id}:attempts"));
-        Assert.Equal(4, await muxer.CountAllKeysAsync());
-
-        workItem = await queue.DequeueAsync();
         Assert.NotNull(workItem);
+        await workItem.AbandonAsync();
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
         Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
         Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:work"));
@@ -359,6 +357,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         // should go to deadletter now
         workItem = await queue.DequeueAsync();
+        Assert.NotNull(workItem);
         await workItem.AbandonAsync();
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
         Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
@@ -380,21 +379,19 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
-        string id = await queue.EnqueueAsync(new SimpleWorkItem
+        string? id = await queue.EnqueueAsync(new SimpleWorkItem
         {
             Data = "blah",
             Id = 1
         });
+        Assert.NotNull(id);
         var workItem = await queue.DequeueAsync();
+        Assert.NotNull(workItem);
         await workItem.AbandonAsync();
-        Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
-        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
-        Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:work"));
-        Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:wait"));
         Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:dequeued"));
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}:enqueued"));
         Assert.False(await db.KeyExistsAsync($"{listPrefix}:{id}:renewed"));
@@ -416,6 +413,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         Assert.InRange(await muxer.CountAllKeysAsync(), 4, 5);
 
         workItem = await queue.DequeueAsync();
+        Assert.NotNull(workItem);
         Assert.True(await db.KeyExistsAsync($"{listPrefix}:{id}"));
         Assert.Equal(0, await db.ListLengthAsync($"{listPrefix}:in"));
         Assert.Equal(1, await db.ListLengthAsync($"{listPrefix}:work"));
@@ -442,14 +440,15 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
         var workItemIds = new List<string>();
         for (int i = 0; i < 10; i++)
         {
-            string id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = i });
+            string? id = await queue.EnqueueAsync(new SimpleWorkItem { Data = "blah", Id = i });
+            Assert.NotNull(id);
             _logger.LogTrace(id);
             workItemIds.Add(id);
         }
@@ -457,6 +456,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         for (int i = 0; i < 10; i++)
         {
             var workItem = await queue.DequeueAsync();
+            Assert.NotNull(workItem);
             await workItem.AbandonAsync();
             _logger.LogTrace("Abandoning: {Id}", workItem.Id);
         }
@@ -499,12 +499,11 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
         await Task.Delay(workItemTimeout.Add(TimeSpan.FromMilliseconds(1)), TestCancellationToken);
 
         // Add an item. DequeueAsync can now return.
-        string id = await queue.EnqueueAsync(new SimpleWorkItem
+        string? id = await queue.EnqueueAsync(new SimpleWorkItem
         {
             Data = itemData,
             Id = itemId
         });
-
         Assert.NotNull(id);
 
         // Run DoMaintenanceWorkAsync to verify that our item will not be auto-abandoned.
@@ -512,6 +511,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         // Completing the item will throw if the item is abandoned.
         var item = await itemTask;
+        Assert.NotNull(item);
         await item.CompleteAsync();
 
         var value = item.Value;
@@ -631,6 +631,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var workItem = await queue.DequeueAsync(TimeSpan.Zero);
         while (workItem != null)
         {
+            Assert.NotNull(workItem.Value);
             Assert.Equal("Hello", workItem.Value.Data);
             if (RandomData.GetBool(10))
                 await workItem.AbandonAsync();
@@ -648,7 +649,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -677,6 +678,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var sw = Stopwatch.StartNew();
         while (workItem != null)
         {
+            Assert.NotNull(workItem.Value);
             Assert.Equal("Hello", workItem.Value.Data);
             await workItem.CompleteAsync();
             work++;
@@ -691,7 +693,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -720,6 +722,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         var sw = Stopwatch.StartNew();
         await queue.StartWorkingAsync(async workItem =>
         {
+            Assert.NotNull(workItem.Value);
             Assert.Equal("Hello", workItem.Value.Data);
             await workItem.CompleteAsync();
             work++;
@@ -736,7 +739,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -750,6 +753,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         {
             await command1Queue.StartWorkingAsync((entry, _) =>
             {
+                Assert.NotNull(entry.Value);
                 _logger.LogInformation("{UtcNow}: Handler1 {Name} {ValueId}", DateTime.UtcNow, entry.Value.GetType().Name, entry.Value.Id);
                 Assert.InRange(entry.Value.Id, 100, 199);
                 return Task.CompletedTask;
@@ -757,6 +761,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
 
             await command2Queue.StartWorkingAsync((entry, _) =>
             {
+                Assert.NotNull(entry.Value);
                 _logger.LogInformation("{UtcNow}: Handler2 {Name} {ValueId}", DateTime.UtcNow, entry.Value.GetType().Name, entry.Value.Id);
                 Assert.InRange(entry.Value.Id, 200, 299);
                 return Task.CompletedTask;
@@ -789,13 +794,13 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
 
     private IQueue<T> CreateQueue<T>(bool allQueuesTheSameName = true) where T : class
     {
-        string name = typeof(T).FullName.Trim().Replace(".", String.Empty).ToLower();
+        string name = typeof(T).FullName!.Trim().Replace(".", String.Empty).ToLower();
 
         if (allQueuesTheSameName)
             name = "cmd";
 
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -816,7 +821,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -38,7 +38,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     {
         var queue = new RedisQueue<SimpleWorkItem>(o =>
         {
-            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+            o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
                 .Retries(retries)
                 .RetryDelay(retryDelay.GetValueOrDefault(TimeSpan.FromMinutes(1)))
                 .RetryMultipliers(retryMultipliers ?? [1, 3, 5, 10])
@@ -212,7 +212,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [RetryFact]
     public override async Task CanDequeueWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -222,7 +222,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     [Fact]
     public override async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         using var cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = muxer, LoggerFactory = Log });
         using var messageBus = new RedisMessageBus(new RedisMessageBusOptions { Subscriber = muxer.GetSubscriber(), Topic = _topic, LoggerFactory = Log });
         var distributedLock = new CacheLockProvider(cache, messageBus, null, Log);
@@ -262,7 +262,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
 
         using (queue)
         {
-            var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+            var muxer = SharedConnection.GetMuxer(Log, Protocol);
             var db = muxer.GetDatabase();
             string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -318,7 +318,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -390,7 +390,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -455,7 +455,7 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
             return;
 
         using RedisQueue<SimpleWorkItem> redisQueue = queue;
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         var db = muxer.GetDatabase();
         string listPrefix = muxer.IsCluster() ? "{q:SimpleWorkItem}" : "q:SimpleWorkItem";
 
@@ -664,7 +664,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed + stats.Deadletter);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -708,7 +708,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -754,7 +754,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
         Assert.Equal(workItemCount, stats.Completed);
         Assert.Equal(0, stats.Queued);
 
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         _logger.LogTrace("# Keys: {KeyCount}", await muxer.CountAllKeysAsync());
     }
 
@@ -815,7 +815,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
             name = "cmd";
 
         var queue = new RedisQueue<T>(o => o
-            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!)
+            .ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol))
             .Name(name)
             .LoggerFactory(Log)
         );
@@ -836,7 +836,7 @@ while ((((tonumber(redis.call(""time"")[1]) - now))) < {DELAY_TIME_SEC}) do end"
     public ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         return new ValueTask(muxer.FlushAllAsync());
     }
 

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -8,21 +8,21 @@ namespace Foundatio.Redis.Tests;
 public static class SharedConnection
 {
     private static readonly object _lock = new();
-    private static ConnectionMultiplexer _muxerResp2;
-    private static ConnectionMultiplexer _muxerResp3;
+    private static ConnectionMultiplexer? _muxerResp2;
+    private static ConnectionMultiplexer? _muxerResp3;
 
     /// <summary>
     /// Returns a shared ConnectionMultiplexer for the given protocol. Two instances are cached (RESP2 and RESP3)
     /// so the test suite can run the same tests under both protocols without reconnecting.
     /// </summary>
-    public static ConnectionMultiplexer GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    public static ConnectionMultiplexer? GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
     {
-        string connectionString = Configuration.GetConnectionString("RedisConnectionString");
+        string? connectionString = Configuration.GetConnectionString("RedisConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return null;
 
         bool useResp3 = protocol >= RedisProtocol.Resp3;
-        ref ConnectionMultiplexer muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;
+        ref ConnectionMultiplexer? muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;
 
         if (muxer is not null)
             return muxer;

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -42,14 +42,4 @@ public static class SharedConnection
             return muxer;
         }
     }
-
-    /// <summary>
-    /// Returns a shared ConnectionMultiplexer or throws if RedisConnectionString is not configured.
-    /// Use this in test setup and test methods that require a live Redis connection.
-    /// </summary>
-    public static ConnectionMultiplexer GetRequiredMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
-    {
-        return GetMuxer(loggerFactory, protocol)
-            ?? throw new InvalidOperationException("RedisConnectionString is not configured. Set it in appsettings.json to run Redis integration tests.");
-    }
 }

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -15,11 +15,12 @@ public static class SharedConnection
     /// Returns a shared ConnectionMultiplexer for the given protocol. Two instances are cached (RESP2 and RESP3)
     /// so the test suite can run the same tests under both protocols without reconnecting.
     /// </summary>
-    public static ConnectionMultiplexer? GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    /// <exception cref="InvalidOperationException">Thrown when RedisConnectionString is not configured.</exception>
+    public static ConnectionMultiplexer GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
     {
         string? connectionString = Configuration.GetConnectionString("RedisConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null;
+            throw new InvalidOperationException("RedisConnectionString is not configured. Set it in the test configuration to run Redis integration tests.");
 
         bool useResp3 = protocol >= RedisProtocol.Resp3;
         ref ConnectionMultiplexer? muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -15,11 +15,11 @@ public static class SharedConnection
     /// Returns a shared ConnectionMultiplexer for the given protocol. Two instances are cached (RESP2 and RESP3)
     /// so the test suite can run the same tests under both protocols without reconnecting.
     /// </summary>
-    public static ConnectionMultiplexer? GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    public static ConnectionMultiplexer GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
     {
         string? connectionString = Configuration.GetConnectionString("RedisConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null;
+            throw new InvalidOperationException("RedisConnectionString is not configured. Set it in the test configuration to run Redis tests.");
 
         bool useResp3 = protocol >= RedisProtocol.Resp3;
         ref ConnectionMultiplexer? muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -14,13 +14,13 @@ public static class SharedConnection
     /// <summary>
     /// Returns a shared ConnectionMultiplexer for the given protocol. Two instances are cached (RESP2 and RESP3)
     /// so the test suite can run the same tests under both protocols without reconnecting.
+    /// Returns <c>null</c> when RedisConnectionString is not configured.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when RedisConnectionString is not configured.</exception>
-    public static ConnectionMultiplexer GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    public static ConnectionMultiplexer? GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
     {
         string? connectionString = Configuration.GetConnectionString("RedisConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            throw new InvalidOperationException("RedisConnectionString is not configured. Set it in the test configuration to run Redis integration tests.");
+            return null;
 
         bool useResp3 = protocol >= RedisProtocol.Resp3;
         ref ConnectionMultiplexer? muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;
@@ -41,5 +41,15 @@ public static class SharedConnection
             });
             return muxer;
         }
+    }
+
+    /// <summary>
+    /// Returns a shared ConnectionMultiplexer or throws if RedisConnectionString is not configured.
+    /// Use this in test setup and test methods that require a live Redis connection.
+    /// </summary>
+    public static ConnectionMultiplexer GetRequiredMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    {
+        return GetMuxer(loggerFactory, protocol)
+            ?? throw new InvalidOperationException("RedisConnectionString is not configured. Set it in appsettings.json to run Redis integration tests.");
     }
 }

--- a/tests/Foundatio.Redis.Tests/SharedConnection.cs
+++ b/tests/Foundatio.Redis.Tests/SharedConnection.cs
@@ -15,11 +15,11 @@ public static class SharedConnection
     /// Returns a shared ConnectionMultiplexer for the given protocol. Two instances are cached (RESP2 and RESP3)
     /// so the test suite can run the same tests under both protocols without reconnecting.
     /// </summary>
-    public static ConnectionMultiplexer GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
+    public static ConnectionMultiplexer? GetMuxer(ILoggerFactory loggerFactory, RedisProtocol? protocol = null)
     {
         string? connectionString = Configuration.GetConnectionString("RedisConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            throw new InvalidOperationException("RedisConnectionString is not configured. Set it in the test configuration to run Redis tests.");
+            return null;
 
         bool useResp3 = protocol >= RedisProtocol.Resp3;
         ref ConnectionMultiplexer? muxer = ref useResp3 ? ref _muxerResp3 : ref _muxerResp2;

--- a/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
+++ b/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
@@ -18,7 +18,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
 
     protected override IFileStorage GetStorage()
     {
-        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log));
+        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log));
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
         await muxer.FlushAllAsync();
     }
 

--- a/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
+++ b/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
@@ -18,7 +18,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
 
     protected override IFileStorage GetStorage()
     {
-        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log));
+        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log));
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
         await muxer.FlushAllAsync();
     }
 

--- a/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
+++ b/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
@@ -16,11 +16,12 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
     {
     }
 
-    protected override IFileStorage GetStorage()
+    protected override IFileStorage? GetStorage()
     {
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
-            return null!;
+            return null;
+
         return new RedisFileStorage(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
     }
 
@@ -156,12 +157,14 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
         var muxer = SharedConnection.GetMuxer(Log, Protocol);
         if (muxer is null)
             return;
+
         await muxer.FlushAllAsync();
     }
 
     public ValueTask DisposeAsync()
     {
         _logger.LogDebug("Disposing");
+
         return ValueTask.CompletedTask;
     }
 }

--- a/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
+++ b/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
@@ -18,7 +18,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
 
     protected override IFileStorage GetStorage()
     {
-        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)!).LoggerFactory(Log));
+        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetMuxer(Log, Protocol)).LoggerFactory(Log));
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetMuxer(Log, Protocol)!;
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
         await muxer.FlushAllAsync();
     }
 

--- a/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
+++ b/tests/Foundatio.Redis.Tests/Storage/RedisFileStorageTests.cs
@@ -18,7 +18,10 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
 
     protected override IFileStorage GetStorage()
     {
-        return new RedisFileStorage(o => o.ConnectionMultiplexer(SharedConnection.GetRequiredMuxer(Log, Protocol)).LoggerFactory(Log));
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return null!;
+        return new RedisFileStorage(o => o.ConnectionMultiplexer(muxer).LoggerFactory(Log));
     }
 
     [Fact]
@@ -150,7 +153,9 @@ public class RedisFileStorageTests : FileStorageTestsBase, IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         _logger.LogDebug("Initializing");
-        var muxer = SharedConnection.GetRequiredMuxer(Log, Protocol);
+        var muxer = SharedConnection.GetMuxer(Log, Protocol);
+        if (muxer is null)
+            return;
         await muxer.FlushAllAsync();
     }
 

--- a/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
+++ b/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
@@ -12,7 +12,7 @@ public class RedisPatternTests
         string? input = null;
 
         // Act
-        string? result = RedisPattern.Escape(input!);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Null(result);
@@ -25,7 +25,7 @@ public class RedisPatternTests
         string input = "";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("", result);
@@ -38,7 +38,7 @@ public class RedisPatternTests
         string input = "normalstring123";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("normalstring123", result);
@@ -51,7 +51,7 @@ public class RedisPatternTests
         string input = "prefix*suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\*suffix", result);
@@ -64,7 +64,7 @@ public class RedisPatternTests
         string input = "prefix?suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\?suffix", result);
@@ -77,7 +77,7 @@ public class RedisPatternTests
         string input = "prefix[abc]suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\[abc\\]suffix", result);
@@ -90,7 +90,7 @@ public class RedisPatternTests
         string input = "prefix\\suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\suffix", result);
@@ -103,7 +103,7 @@ public class RedisPatternTests
         string input = "prefix\\*suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\*suffix", result);
@@ -116,7 +116,7 @@ public class RedisPatternTests
         string input = "prefix\\?suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\?suffix", result);
@@ -129,7 +129,7 @@ public class RedisPatternTests
         string input = "prefix\\[abc\\]suffix";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\[abc\\\\\\]suffix", result);
@@ -142,7 +142,7 @@ public class RedisPatternTests
         string input = "test*?[abc]";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\*\\?\\[abc\\]", result);
@@ -155,7 +155,7 @@ public class RedisPatternTests
         string input = "test\\**?[abc]";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\\\*\\*\\?\\[abc\\]", result);
@@ -168,7 +168,7 @@ public class RedisPatternTests
         string input = "test\\\\*";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\\\\\\\*", result);
@@ -181,7 +181,7 @@ public class RedisPatternTests
         string input = "test\\";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\", result);
@@ -194,7 +194,7 @@ public class RedisPatternTests
         string input = "test\\a";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\a", result);
@@ -207,7 +207,7 @@ public class RedisPatternTests
         string input = "**??[[]]";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\*\\*\\?\\?\\[\\[\\]\\]", result);
@@ -220,7 +220,7 @@ public class RedisPatternTests
         string input = "*?[]";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\*\\?\\[\\]", result);
@@ -233,7 +233,7 @@ public class RedisPatternTests
         string input = "user:*:session[?]\\already\\*escaped";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("user:\\*:session\\[\\?\\]\\\\already\\\\\\*escaped", result);
@@ -246,7 +246,7 @@ public class RedisPatternTests
         string input = "cache:user[123]:data*";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("cache:user\\[123\\]:data\\*", result);
@@ -262,7 +262,7 @@ public class RedisPatternTests
     public void Escape_WithSingleCharacterInputs_HandlesCorrectly(string input, string expected)
     {
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal(expected, result);
@@ -275,7 +275,7 @@ public class RedisPatternTests
         string input = "\\*";
 
         // Act
-        string result = RedisPattern.Escape(input);
+        var result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\\\\\*", result);

--- a/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
+++ b/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
@@ -25,7 +25,7 @@ public class RedisPatternTests
         string input = "";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("", result);
@@ -38,7 +38,7 @@ public class RedisPatternTests
         string input = "normalstring123";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("normalstring123", result);
@@ -51,7 +51,7 @@ public class RedisPatternTests
         string input = "prefix*suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\*suffix", result);
@@ -64,7 +64,7 @@ public class RedisPatternTests
         string input = "prefix?suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\?suffix", result);
@@ -77,7 +77,7 @@ public class RedisPatternTests
         string input = "prefix[abc]suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\[abc\\]suffix", result);
@@ -90,7 +90,7 @@ public class RedisPatternTests
         string input = "prefix\\suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\suffix", result);
@@ -103,7 +103,7 @@ public class RedisPatternTests
         string input = "prefix\\*suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\*suffix", result);
@@ -116,7 +116,7 @@ public class RedisPatternTests
         string input = "prefix\\?suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\?suffix", result);
@@ -129,7 +129,7 @@ public class RedisPatternTests
         string input = "prefix\\[abc\\]suffix";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("prefix\\\\\\[abc\\\\\\]suffix", result);
@@ -142,7 +142,7 @@ public class RedisPatternTests
         string input = "test*?[abc]";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\*\\?\\[abc\\]", result);
@@ -155,7 +155,7 @@ public class RedisPatternTests
         string input = "test\\**?[abc]";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\\\*\\*\\?\\[abc\\]", result);
@@ -168,7 +168,7 @@ public class RedisPatternTests
         string input = "test\\\\*";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\\\\\\\*", result);
@@ -181,7 +181,7 @@ public class RedisPatternTests
         string input = "test\\";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\", result);
@@ -194,7 +194,7 @@ public class RedisPatternTests
         string input = "test\\a";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("test\\\\a", result);
@@ -207,7 +207,7 @@ public class RedisPatternTests
         string input = "**??[[]]";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\*\\*\\?\\?\\[\\[\\]\\]", result);
@@ -220,7 +220,7 @@ public class RedisPatternTests
         string input = "*?[]";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\*\\?\\[\\]", result);
@@ -233,7 +233,7 @@ public class RedisPatternTests
         string input = "user:*:session[?]\\already\\*escaped";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("user:\\*:session\\[\\?\\]\\\\already\\\\\\*escaped", result);
@@ -246,7 +246,7 @@ public class RedisPatternTests
         string input = "cache:user[123]:data*";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("cache:user\\[123\\]:data\\*", result);
@@ -262,7 +262,7 @@ public class RedisPatternTests
     public void Escape_WithSingleCharacterInputs_HandlesCorrectly(string input, string expected)
     {
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal(expected, result);
@@ -275,7 +275,7 @@ public class RedisPatternTests
         string input = "\\*";
 
         // Act
-        var result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input);
 
         // Assert
         Assert.Equal("\\\\\\*", result);

--- a/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
+++ b/tests/Foundatio.Redis.Tests/Utility/RedisPatternTests.cs
@@ -9,10 +9,10 @@ public class RedisPatternTests
     public void Escape_WithNullInput_ReturnsNull()
     {
         // Arrange
-        string input = null;
+        string? input = null;
 
         // Act
-        string result = RedisPattern.Escape(input);
+        string? result = RedisPattern.Escape(input!);
 
         // Assert
         Assert.Null(result);


### PR DESCRIPTION
## Summary
- Replaced the ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ (which expects warning IDs, not a boolean) with the correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed all CS86xx nullable reference warnings that were previously hidden
- Added missing \where T : notnull\ constraints to match ICacheClient interface
- Added proper null guards in tests and null-conditional access in library code

## Changes
- **build/common.props**: \WarningsAsErrors\ → \TreatWarningsAsErrors\
- **RedisCacheClient.cs**: Added \where T : notnull\ to \GetListAsync\, \ListAddAsync\, \ListRemoveAsync\ and private helpers
- **RedisMessageBus.cs**: Null-safe envelope property access
- **RedisQueue.cs**: Null-coalescing for poison entry ID
- **RedisFileStorage.cs**: Non-null fallbacks for LogState.Property calls
- **RedisExtensions.cs**: \[return: MaybeNull]\ on \ToValueOfType<T>()\
- **Tests/Samples**: \Assert.NotNull\ guards and null-conditional access

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors