### PR TITLE
fix: adapt Redis MessageBus to two-phase dispose lifecycle

### DIFF
--- a/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
+++ b/samples/Foundatio.SampleJobClient/Foundatio.SampleJobClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta5" />
+    <PackageReference Include="Foundatio.Xunit.v3" Version="13.0.0-beta5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="3.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="3.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -171,6 +171,9 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
         using (await _lock.LockAsync().AnyContext())
         {
+            if (!_isSubscribed)
+                return;
+
             if (_channelMessageQueue is not null)
             {
                 _logger.LogTrace("Unsubscribing from topic {Topic}", _options.Topic);
@@ -183,9 +186,10 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
                     _logger.LogError(ex, "Error unsubscribing from topic {Topic}: {Message}", _options.Topic, ex.Message);
                 }
                 _channelMessageQueue = null;
-                _isSubscribed = false;
-                _logger.LogTrace("Unsubscribed from topic {Topic}", _options.Topic);
             }
+
+            _isSubscribed = false;
+            _logger.LogTrace("Unsubscribed from topic {Topic}", _options.Topic);
         }
     }
 }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -128,6 +128,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         }
         catch (Exception ex)
         {
+            // Catch any other unexpected exceptions for defensive purposes
             _logger.LogError(ex, "OnMessage({Channel}) Error in subscriber: {Message}", channelMessage.Channel, ex.Message);
         }
     }
@@ -165,6 +166,9 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
     protected override async Task CleanupAsync()
     {
+        if (!_isSubscribed)
+            return;
+
         using (await _lock.LockAsync().AnyContext())
         {
             if (_channelMessageQueue is not null)

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -165,17 +165,14 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
 
     protected override async Task CleanupAsync()
     {
-        if (_isSubscribed)
+        using (await _lock.LockAsync().AnyContext())
         {
-            using (await _lock.LockAsync().AnyContext())
+            if (_channelMessageQueue is not null)
             {
-                if (!_isSubscribed)
-                    return;
-
                 _logger.LogTrace("Unsubscribing from topic {Topic}", _options.Topic);
                 try
                 {
-                    _channelMessageQueue?.Unsubscribe(CommandFlags.FireAndForget);
+                    _channelMessageQueue.Unsubscribe(CommandFlags.FireAndForget);
                 }
                 catch (Exception ex)
                 {

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -117,7 +117,7 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         {
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (IsDisposed)
         {
             // Bus is disposing — Redis pub/sub is fire-and-forget, message is lost
         }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -117,6 +117,10 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         {
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
+        catch (OperationCanceledException)
+        {
+            // Bus is disposing — Redis pub/sub is fire-and-forget, message is lost
+        }
         catch (MessageBusException)
         {
             // SendMessageToSubscribersAsync already logged the error
@@ -124,7 +128,6 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
         }
         catch (Exception ex)
         {
-            // Catch any other unexpected exceptions for defensive purposes
             _logger.LogError(ex, "OnMessage({Channel}) Error in subscriber: {Message}", channelMessage.Channel, ex.Message);
         }
     }
@@ -160,13 +163,11 @@ public class RedisMessageBus : MessageBusBase<RedisMessageBusOptions>
             cancellationToken).AnyContext();
     }
 
-    public override void Dispose()
+    protected override async Task CleanupAsync()
     {
-        base.Dispose();
-
         if (_isSubscribed)
         {
-            using (_lock.Lock())
+            using (await _lock.LockAsync().AnyContext())
             {
                 if (!_isSubscribed)
                     return;

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -80,24 +80,6 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
-    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
-    {
-        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
     public override Task CanSubscribeConcurrentlyAsync()
     {
         return base.CanSubscribeConcurrentlyAsync();
@@ -170,6 +152,12 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public override Task CanHandlePoisonedMessageAsync()
+    {
+        return base.CanHandlePoisonedMessageAsync();
+    }
+
+    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -194,6 +182,24 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
+    {
+        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
         return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
@@ -206,27 +212,21 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
-    public override Task CanHandlePoisonedMessageAsync()
+    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        return base.CanHandlePoisonedMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
     }
 
     [Fact]
     public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
     {
         return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
+    {
+        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -170,6 +170,42 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task CanHandlePoisonedMessageAsync()
     {
         return base.CanHandlePoisonedMessageAsync();

--- a/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
+++ b/tests/Foundatio.Redis.Tests/Messaging/RedisMessageBusTests.cs
@@ -164,9 +164,9 @@ public class RedisMessageBusTests : MessageBusTestBase, IAsyncLifetime
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Move unsubscribe logic from Dispose to \CleanupAsync\ override
- Handle \OperationCanceledException\ in \OnMessage\ (Redis pub/sub is fire-and-forget)
- Remove ad-hoc Dispose cleanup

## Dependencies
- Depends on FoundatioFx/Foundatio#492 (core two-phase dispose)

## Test plan
- [x] Builds with local Foundatio source (\ReferenceFoundatioSource=true\)
- [ ] CI runs integration tests with Redis