### PR TITLE
Replace deprecated RPOPLPUSH with LMOVE and add SE.Redis compatibility notes

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/samples/Foundatio.SampleJob/Foundatio.SampleJob.csproj
+++ b/samples/Foundatio.SampleJob/Foundatio.SampleJob.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless.RandomData" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Redis/Cache/RedisCacheClient.cs
+++ b/src/Foundatio.Redis/Cache/RedisCacheClient.cs
@@ -1010,6 +1010,8 @@ public sealed class RedisCacheClient : ICacheClient, IHaveSerializer
         _logger.LogWarning("Redis connection failed: {FailureType}", connectionFailedEventArgs.FailureType);
     }
 
+    // NOTE: Implement IAsyncDisposable when Foundatio's ICacheClient interface adds support for it.
+    // IConnectionMultiplexer supports IAsyncDisposable since SE.Redis 2.6.66.
     public void Dispose()
     {
         if (_isDisposed)

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Foundatio" Version="13.0.1" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
-    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Scripts\*.lua" />

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -805,6 +805,8 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         return script ?? throw new QueueException("Lua scripts not loaded. Call LoadScriptsAsync first.");
     }
 
+    // NOTE: Implement IAsyncDisposable when Foundatio's IQueue interface adds support for it.
+    // IConnectionMultiplexer supports IAsyncDisposable since SE.Redis 2.6.66.
     public override void Dispose()
     {
         base.Dispose();

--- a/src/Foundatio.Redis/Scripts/DequeueId.lua
+++ b/src/Foundatio.Redis/Scripts/DequeueId.lua
@@ -1,4 +1,4 @@
-﻿local item = redis.call('RPOPLPUSH', @queueListName, @workListName);
+﻿local item = redis.call('LMOVE', @queueListName, @workListName, 'RIGHT', 'LEFT');
 if item then
     local dequeuedTimeKey = @listPrefix .. ':' .. item .. ':dequeued';
     local renewedTimeKey = @listPrefix .. ':' .. item .. ':renewed';

--- a/src/Foundatio.Redis/Scripts/RemoveIfEqual.lua
+++ b/src/Foundatio.Redis/Scripts/RemoveIfEqual.lua
@@ -1,4 +1,6 @@
-﻿if redis.call('get', @key) == @expected then
+﻿-- NOTE: When Redis 8.4+ becomes the minimum supported version, this script can be replaced
+-- with native CAS/CAD: DEL @key IFEQ @expected (SE.Redis 2.10.1+ supports this via ValueCondition).
+if redis.call('get', @key) == @expected then
   return redis.call('del', @key)
 else
   return 0

--- a/src/Foundatio.Redis/Scripts/ReplaceIfEqual.lua
+++ b/src/Foundatio.Redis/Scripts/ReplaceIfEqual.lua
@@ -1,4 +1,6 @@
-﻿local currentVal = redis.call('get', @key)
+﻿-- NOTE: When Redis 8.4+ becomes the minimum supported version, this script can be replaced
+-- with native CAS/CAD: SET @key @value IFEQ @expected [PX @expires] (SE.Redis 2.10.1+ supports this via ValueCondition).
+local currentVal = redis.call('get', @key)
 if (currentVal == false or currentVal == @expected) then
   if (@expires ~= nil and @expires ~= '') then
     return redis.call('set', @key, @value, 'PX', @expires) and 1 or 0

--- a/src/Foundatio.Redis/Storage/RedisFileStorage.cs
+++ b/src/Foundatio.Redis/Storage/RedisFileStorage.cs
@@ -47,6 +47,8 @@ public class RedisFileStorage : IFileStorage
     ISerializer IHaveSerializer.Serializer => _serializer;
     public IDatabase Database => _connectionMultiplexer.GetDatabase();
 
+    // NOTE: Implement IAsyncDisposable when Foundatio's IFileStorage interface adds support for it.
+    // IConnectionMultiplexer supports IAsyncDisposable since SE.Redis 2.6.66.
     public void Dispose()
     {
         _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;


### PR DESCRIPTION
## Summary

- Replace deprecated `RPOPLPUSH` with `LMOVE` in `DequeueId.lua` (available since Redis 6.2, RPOPLPUSH deprecated)
- Add NOTE comments to `RemoveIfEqual.lua` and `ReplaceIfEqual.lua` about replacing with native CAS/CAD commands (`SET ... IFEQ` / `DEL ... IFEQ`) when Redis 8.4+ becomes the minimum supported version (SE.Redis 2.10.1+)
- Add NOTE comments next to `Dispose()` in `RedisCacheClient`, `RedisFileStorage`, and `RedisQueue` about implementing `IAsyncDisposable` when Foundatio base interfaces add support
- Update `StackExchange.Redis` to 2.13.1 (RESP3 default for Azure Managed Redis endpoints)

## Context

Based on review of https://stackexchange.github.io/StackExchange.Redis/ and https://stackexchange.github.io/StackExchange.Redis/Resp3:
- RESP3 compatibility is already well-covered by existing test classes running under both protocols
- No obsolete SE.Redis APIs are in use
- Lua scripts return simple types unaffected by RESP3 type conversions

## Test plan

- [ ] Existing tests pass (RPOPLPUSH -> LMOVE is a behavioral equivalent)
- [ ] RESP3 test classes continue to pass
- [ ] Verify Redis 6.2+ is the minimum in CI (LMOVE requires 6.2+)