### PR TITLE
fix: correct RedisQueue disposal ordering to prevent ObjectDisposedException during shutdown

### DIFF
--- a/samples/Foundatio.SampleJob/Foundatio.SampleJob.csproj
+++ b/samples/Foundatio.SampleJob/Foundatio.SampleJob.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless.RandomData" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Redis/Foundatio.Redis.csproj
+++ b/src/Foundatio.Redis/Foundatio.Redis.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Foundatio" Version="13.0.2-preview.0.4" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
-    <PackageReference Include="StackExchange.Redis" Version="2.13.10" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Scripts\*.lua" />

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -809,7 +809,10 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     // IConnectionMultiplexer supports IAsyncDisposable since SE.Redis 2.6.66.
     public override void Dispose()
     {
-        base.Dispose();
+        if (IsDisposed)
+            return;
+
+        SignalDispose();
         _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
 
         if (_isSubscribed)
@@ -853,6 +856,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         }
 
         WaitForMaintenanceTask();
+        base.Dispose();
         _cache.Dispose();
     }
 

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -810,7 +810,10 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     public override void Dispose()
     {
         if (IsDisposed)
+        {
+            _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
             return;
+        }
 
         SignalDispose();
         _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;

--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -809,13 +809,11 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     // IConnectionMultiplexer supports IAsyncDisposable since SE.Redis 2.6.66.
     public override void Dispose()
     {
-        if (IsDisposed)
+        if (!SignalDispose())
         {
             _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
             return;
         }
-
-        SignalDispose();
         _connectionMultiplexer.ConnectionRestored -= ConnectionMultiplexerOnConnectionRestored;
 
         if (_isSubscribed)

--- a/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
+++ b/tests/Foundatio.Redis.Tests/Foundatio.Redis.Tests.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />

--- a/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
+++ b/tests/Foundatio.Redis.Tests/Queues/RedisQueueTests.cs
@@ -129,6 +129,12 @@ public class RedisQueueTests : QueueTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public override Task Dispose_WithMaintenanceRunning_DoesNotThrowObjectDisposedException()
+    {
+        return base.Dispose_WithMaintenanceRunning_DoesNotThrowObjectDisposedException();
+    }
+
+    [Fact]
     public override Task DequeueWaitWillGetSignaledAsync()
     {
         return base.DequeueWaitWillGetSignaledAsync();


### PR DESCRIPTION
## Summary

- Reorders `RedisQueue.Dispose()` to call `SignalDispose()` first, wait for workers and maintenance task, then `base.Dispose()` last
- Adds `Dispose_WithMaintenanceRunning_DoesNotThrowObjectDisposedException` test wiring

## Root Cause

`RedisQueue.Dispose()` called `base.Dispose()` first which destroyed the `CancellationTokenSource` before the maintenance task was waited on. The still-running `DoMaintenanceWorkLoopAsync` then accessed `DisposedCancellationToken` (calling `.Token` on the disposed CTS), throwing `ObjectDisposedException` logged as a warning during Kubernetes graceful shutdown.

## Dependencies

Requires FoundatioFx/Foundatio#519 (introduces `SignalDispose()` in `MaintenanceBase`)

## Test plan

- [x] New test validates dispose does not throw with maintenance running
- [x] All existing queue tests pass

Fixes #165