### PR TITLE
Version-gate LMOVE for Redis 6.0.x compatibility (Azure Cache for Redis)

### DIFF
--- a/src/Foundatio.Redis/Queues/RedisQueue.cs
+++ b/src/Foundatio.Redis/Queues/RedisQueue.cs
@@ -22,6 +22,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     private readonly ISubscriber _subscriber;
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisCacheClient _cache;
+    private readonly RedisCapabilities _capabilities;
     private long _enqueuedCount;
     private long _dequeuedCount;
     private long _completedCount;
@@ -44,6 +45,8 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
         _connectionMultiplexer = options.ConnectionMultiplexer;
 
         _connectionMultiplexer.ConnectionRestored += ConnectionMultiplexerOnConnectionRestored;
+
+        _capabilities = new RedisCapabilities(_connectionMultiplexer, _logger);
 
         _cache = new RedisCacheClient(new RedisCacheClientOptions { ConnectionMultiplexer = _connectionMultiplexer, Serializer = _serializer, ReadMode = options.ReadMode, Database = options.Database });
 
@@ -655,6 +658,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     {
         _logger.LogInformation("Redis connection restored");
         _scriptsLoaded = false;
+        _capabilities.Invalidate();
         _autoResetEvent.Set();
     }
 
@@ -782,7 +786,9 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
             if (_scriptsLoaded)
                 return;
 
-            var dequeueId = LuaScript.Prepare(DequeueIdScript);
+            bool useLMove = _capabilities.SupportsLMove;
+            _logger.LogDebug("Loading DequeueId script using {Command} variant", useLMove ? "LMOVE" : "RPOPLPUSH");
+            var dequeueId = LuaScript.Prepare(useLMove ? DequeueIdScript : DequeueIdRpoplpushScript);
 
             foreach (var endpoint in _connectionMultiplexer.GetEndPoints())
             {
@@ -882,6 +888,7 @@ public class RedisQueue<T> : QueueBase<T, RedisQueueOptions<T>> where T : class
     }
 
     private static readonly string DequeueIdScript = EmbeddedResourceLoader.GetEmbeddedResource("Foundatio.Redis.Scripts.DequeueId.lua");
+    private static readonly string DequeueIdRpoplpushScript = EmbeddedResourceLoader.GetEmbeddedResource("Foundatio.Redis.Scripts.DequeueId.Rpoplpush.lua");
 }
 
 public record RedisPayloadEnvelope<T>

--- a/src/Foundatio.Redis/Scripts/DequeueId.Rpoplpush.lua
+++ b/src/Foundatio.Redis/Scripts/DequeueId.Rpoplpush.lua
@@ -1,0 +1,10 @@
+local item = redis.call('RPOPLPUSH', @queueListName, @workListName);
+if item then
+    local dequeuedTimeKey = @listPrefix .. ':' .. item .. ':dequeued';
+    local renewedTimeKey = @listPrefix .. ':' .. item .. ':renewed';
+    redis.call('SET', dequeuedTimeKey, @now, 'PX', @timeout);
+    redis.call('SET', renewedTimeKey, @now, 'PX', @timeout);
+    return item;
+else
+    return nil;
+end

--- a/src/Foundatio.Redis/Utility/RedisCapabilities.cs
+++ b/src/Foundatio.Redis/Utility/RedisCapabilities.cs
@@ -7,11 +7,13 @@ namespace Foundatio.Redis.Utility;
 
 internal sealed class RedisCapabilities
 {
+    private static readonly Version LMoveMinVersion = new(6, 2, 0);
     private static readonly Version MsetexMinVersion = new(8, 3, 224);
 
     private readonly IConnectionMultiplexer _muxer;
     private readonly ILogger _logger;
 
+    private int _lMove; // 0 = unknown, 1 = supported, -1 = not supported
     private int _msetex; // 0 = unknown, 1 = supported, -1 = not supported
 
     public RedisCapabilities(IConnectionMultiplexer muxer, ILogger logger)
@@ -23,10 +25,17 @@ internal sealed class RedisCapabilities
         _logger = logger;
     }
 
+    /// <summary>
+    /// LMOVE requires Redis 6.2+. Callers should fall back to the (functionally identical) RPOPLPUSH
+    /// variant when this returns <c>false</c>, e.g. against Azure Cache for Redis, which is pinned at 6.0.x.
+    /// </summary>
+    public bool SupportsLMove => CheckVersion(ref _lMove, LMoveMinVersion, "LMOVE");
+
     public bool SupportsMsetex => CheckVersion(ref _msetex, MsetexMinVersion, "MSETEX");
 
     public void Invalidate()
     {
+        Volatile.Write(ref _lMove, 0);
         Volatile.Write(ref _msetex, 0);
     }
 


### PR DESCRIPTION
Fixes #174

## Root cause

`Scripts/DequeueId.lua` calls `LMOVE`, which requires **Redis 6.2+**. PR #164 replaced the deprecated `RPOPLPUSH` with `LMOVE` without a version gate. Azure Cache for Redis is pinned at **6.0.14**, so every dequeue throws:

```
ERR Error running script (...): Unknown Redis command called from Lua script
```

Confirmed directly against a live Azure Cache for Redis instance (server reports `v6.0.14`).

## Fix

- Added `RedisCapabilities.SupportsLMove` (min version `6.2.0`), mirroring the existing `SupportsMsetex` version-gate pattern.
- `RedisQueue.LoadScriptsAsync` now selects the `LMOVE` script on 6.2+ servers and falls back to a restored `RPOPLPUSH` variant (`DequeueId.Rpoplpush.lua`) on older servers.
- The capability cache is invalidated on reconnect (`ConnectionMultiplexerOnConnectionRestored`), same as `SupportsMsetex`.

## Audit: fallback script correctness

`DequeueId.Rpoplpush.lua` was verified against the exact pre-#164 script (`git show f77ee64^:src/Foundatio.Redis/Scripts/DequeueId.lua`). The Lua logic is **byte-for-byte identical**; the only difference is a UTF-8 BOM and trailing newline in the old file, both of which are inconsequential (`EmbeddedResourceLoader` uses `StreamReader`, which strips a BOM by default, and other scripts in the repo already have mixed BOM/no-BOM and trailing-newline conventions).

`LMOVE src dst RIGHT LEFT` is functionally identical to `RPOPLPUSH src dst`, so behavior is unchanged regardless of which variant is selected.

## Verification

- Build: clean, 0 warnings / 0 errors.
- **Local Redis 6.0.20** (matches Azure's 6.0.14): full `RedisQueueTests` suite — 48 passed, 0 failed, 5 skipped, no `LMOVE` errors. Since 6.0 has no `LMOVE`, this confirms the `RPOPLPUSH` fallback is correctly selected and functioning.
- **Local Redis 7.4.9**: dequeue tests pass, confirming the `LMOVE` path is still used (and preferred) on modern servers.

## Scope

This PR only addresses the `LMOVE` incompatibility from #174. It does not touch the separately-reported cache expiration test flakiness (which is a test-latency issue against high-RTT connections, unrelated to Redis version support).